### PR TITLE
Add container and authentication steps to publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,14 +7,29 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/goldenm-software/flutter-web-builder:3.13.5
+      options: --user root
+      credentials:
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Authenticate
+        run: |
+          echo "${{ secrets.PUB_TOKEN }}" > $HOME/.credentials.json
+          gcloud auth activate-service-account --key-file=$HOME/.credentials.json
+          gcloud auth print-identity-token --audiences=https://pub.dev | dart pub token add https://pub.dev
+      
       - name: Publish
-        uses: sakebook/actions-flutter-pub-publisher@v1.4.1
-        with:
-          credential: ${{ secrets.PUB_TOKEN }}
-          flutter_package: true
-          skip_test: true
-          dry_run: true
+        run: |
+          flutter pub publish --force
+      
+      - name: Cleanup
+        run: |
+          rm $HOME/.credentials.json
+          dart pub token remove https://pub.dev
+


### PR DESCRIPTION
This pull request adds a container step to the publish job, using the ghcr.io/goldenm-software/flutter-web-builder:3.13.5 image with root user permissions and GitHub credentials. It also adds an authentication step to authenticate with Google Cloud Platform and Pub.dev. Finally, it replaces the previous publish step with a command to publish the package using Flutter's built-in pub tool.