### PR TITLE
v4.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 4.3.3
+- Changed `ThemedTable<T>` border colors, now use `Theme.of(context).dividerColor` instead of `Colors.grey.shade300`
+- Some fixes related to `drawAvatar`.
+
+## 4.3.2
+- Added `context` in `ThemedSnackbar` to backward compatibility with `@Deprecated` warning.
+
 ## 4.3.1
 - New `ThemedSnackbar` to show a snackbar with a custom messenger called `ThemedSnackbarMessenger`. Now you can show a snackbar from anywhere in the app only calling `ThemedSnackbarMessenger.of(context).showSnackbar(...)`.
 - Deprecated void functions `showThemedSnackbar` and `setThemedSnackbarScaffoldKey` in favor of the new `ThemedSnackbarMessenger` and `ThemedSnackbar` widgets.

--- a/example/lib/router.dart
+++ b/example/lib/router.dart
@@ -104,6 +104,6 @@ final goRoutes = [
 ];
 
 final router = GoRouter(
-  initialLocation: kDebugMode ? '/inputs/buttons' : '/',
+  initialLocation: kDebugMode ? '/table/basic' : '/',
   routes: goRoutes,
 );

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -326,7 +326,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.3.2"
+    version: "4.3.3"
   linked_scroll_controller:
     dependency: transitive
     description:

--- a/lib/src/helpers/src/draw_avatar.dart
+++ b/lib/src/helpers/src/draw_avatar.dart
@@ -73,7 +73,7 @@ Widget drawAvatar({
   if (dynamicAvatar != null) {
     switch (dynamicAvatar.type) {
       case AvatarType.emoji:
-        containerColor = Colors.grey.shade900;
+        containerColor = color ?? Colors.white;
         content = Center(
           child: Text(
             dynamicAvatar.emoji ?? 'NA',
@@ -84,6 +84,7 @@ Widget drawAvatar({
         );
         break;
       case AvatarType.icon:
+        containerColor = color ?? Colors.white;
         content = Icon(
           dynamicAvatar.icon ?? Icons.person,
           color: validateColor(color: containerColor),
@@ -133,7 +134,7 @@ Widget drawAvatar({
         break;
     }
   } else if (avatar != null && avatar.isNotEmpty) {
-    containerColor = Colors.white;
+    containerColor = color ?? Colors.white;
     if (avatar.startsWith('data:')) {
       content = Image.memory(
         base64Decode(avatar.split(',').last),
@@ -194,14 +195,14 @@ Widget drawAvatar({
       borderRadius: BorderRadius.circular(radius),
       border: elevation == 0
           ? Border.all(
-              color: shadowColor ?? Theme.of(context).dividerColor,
+              color: shadowColor ?? containerColor,
               width: 1,
             )
           : null,
       boxShadow: elevation > 0
           ? [
               BoxShadow(
-                color: shadowColor ?? Theme.of(context).dividerColor,
+                color: shadowColor ?? containerColor,
                 blurRadius: 2 * elevation.toDouble(),
                 offset: Offset(0, elevation.toDouble() * (reverse ? -1 : 1)), // changes position of shadow
               ),

--- a/lib/src/layout/src/parts/avatar.dart
+++ b/lib/src/layout/src/parts/avatar.dart
@@ -114,6 +114,8 @@ class _ThemedAppBarAvatarState extends State<ThemedAppBarAvatar> with SingleTick
           radius: widget.asTaskBar ? 5 : 30,
           name: widget.userName,
           dynamicAvatar: widget.userDynamicAvatar,
+          elevation: 3,
+          color: Theme.of(context).scaffoldBackgroundColor,
         ),
       ),
     );

--- a/lib/src/scaffolds/src/table/table.dart
+++ b/lib/src/scaffolds/src/table/table.dart
@@ -364,7 +364,8 @@ class _ThemedTableState<T> extends State<ThemedTable<T>> with TickerProviderStat
 
   /// [border] refers to the style of the border of the cells.
   BorderSide get border => BorderSide(
-        color: Colors.grey.shade300,
+        // color: isDark ? Colors.grey.shade800 : Colors.grey.shade300,
+        color: Theme.of(context).dividerColor,
         width: 1.5,
       );
 

--- a/lib/src/snackbar/src/snackbar.dart
+++ b/lib/src/snackbar/src/snackbar.dart
@@ -1,7 +1,7 @@
 part of '../snackbar.dart';
 
 class ThemedSnackbar extends StatefulWidget {
-  @Deprecated('Removed in 4.3.0 is no longer used')
+  /// [context] helps to build the snackbar. If null, the snackbar will not be displayed
   final BuildContext? context;
 
   /// [title] helps to build the title widget. If null, the title will not be displayed
@@ -34,7 +34,7 @@ class ThemedSnackbar extends StatefulWidget {
   ThemedSnackbar({
     Key? key,
     this.title,
-    this.context,
+    @Deprecated('Removed in 4.3.0 is no longer used') this.context,
     required this.message,
     this.icon,
     this.color,

--- a/lib/src/theme/src/dark_theme.dart
+++ b/lib/src/theme/src/dark_theme.dart
@@ -157,9 +157,14 @@ ThemeData generateDarkTheme({
       endIndent: 0,
     ),
     scrollbarTheme: ScrollbarThemeData(
+      trackVisibility: MaterialStateProperty.all(true),
+      thumbVisibility: MaterialStateProperty.all(true),
       thumbColor: MaterialStateColor.resolveWith((states) {
-        return Colors.grey.shade700.withOpacity(0.4);
+        return Colors.grey.shade500.withOpacity(0.4);
       }),
+      trackColor: MaterialStateProperty.all(Colors.transparent),
+      trackBorderColor: MaterialStateProperty.all(Colors.transparent),
+      thickness: MaterialStateProperty.all(7),
     ),
 
     // Inputs

--- a/lib/src/theme/src/light_theme.dart
+++ b/lib/src/theme/src/light_theme.dart
@@ -172,6 +172,8 @@ ThemeData generateLightTheme({
       thumbColor: MaterialStateColor.resolveWith((states) {
         return Colors.black.withOpacity(0.4);
       }),
+      trackColor: MaterialStateProperty.all(Colors.transparent),
+      trackBorderColor: MaterialStateProperty.all(Colors.transparent),
       thickness: MaterialStateProperty.all(7),
     ),
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: layrz_theme
 description: Layrz standard theme library for Flutter, based on Material You (Material 3).
-version: "4.3.2"
+version: "4.3.3"
 repository: https://github.com/goldenm-software/layrz_theme
 
 topics:


### PR DESCRIPTION
- Changed `ThemedTable<T>` border colors, now use `Theme.of(context).dividerColor` instead of `Colors.grey.shade300`
- Some fixes related to `drawAvatar`.