### PR TITLE
Add onFilteredCountChanged callback and restore prefixIcon

### DIFF
--- a/.claude/skills/themed-table-2/SKILL.md
+++ b/.claude/skills/themed-table-2/SKILL.md
@@ -49,6 +49,7 @@ Always wrap in `Expanded` or give a fixed height — `ThemedTable2` requires bou
 - `actionsCount` must equal the number of buttons `actionsBuilder` actually returns — assert enforced.
 - `hasMultiselect: true` requires at least one entry in `multiselectActions` — assert enforced.
 - `onTapDefaultBehavior` defaults to `.copyToClipboard`; set to `.none` to disable.
+- `onFilteredCountChanged` fires after every `_filterAndSort` cycle (initial load, search, sort, `items` update) with the visible row count. Fires with `0` for an empty dataset. Optional — `null` by default, no overhead when omitted.
 
 ---
 
@@ -127,6 +128,18 @@ ThemedTable2<Asset>(
       onTap: () => _onDeleteSelected(_selected.value),
     ),
   ],
+  columns: [ /* ... */ ],
+)
+
+// With filtered count callback
+ThemedTable2<Asset>(
+  items: _items,
+  canSearch: true,
+  actionsCount: 0,
+  hasMultiselect: false,
+  onFilteredCountChanged: (count) {
+    setState(() => _visibleCount = count);
+  },
   columns: [ /* ... */ ],
 )
 

--- a/.claude/skills/themed-table-2/references/api.md
+++ b/.claude/skills/themed-table-2/references/api.md
@@ -96,6 +96,7 @@ const ThemedTable2({
   this.onTapDefaultBehavior = .copyToClipboard,
   this.copyToClipboardText,
   this.controller,
+  this.onFilteredCountChanged,
 })
 // Asserts:
 // - columns.length > 0
@@ -121,6 +122,7 @@ const ThemedTable2({
 | `canSearch` | `bool` | `true` | Shows search input above the table |
 | `onTapDefaultBehavior` | `ThemedTable2OnTapBehavior` | `.copyToClipboard` | Cell tap behavior when no `onTap` on column |
 | `controller` | `ThemedTable2Controller<T>?` | `null` | Programmatic sort/refresh |
+| `onFilteredCountChanged` | `void Function(int count)?` | `null` | Called after each filter+sort cycle with the visible row count |
 | `populateDelay` | `Duration` | `150ms` | Delay before rendering data |
 | `minColumnWidth` | `double` | `250` | Minimum width for flex columns |
 | `headerHeight` | `double` | `40` | Header row height |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 7.5.29
 
 - Added `onFilteredCountChanged: void Function(int count)?` to `ThemedTable2<T>`. The callback fires after every filter-and-sort cycle (initial load, search, sort, `items` update) with the count of currently visible rows. Optional and `null` by default — fully backward-compatible.
+- Restored `prefixIcon` parameter in `ThemedColorPicker` as `@Deprecated`. The parameter was removed in 7.5.27 but is still referenced in downstream packages. It is now accepted (and ignored) to restore build compatibility while consumers migrate.
 
 ## 7.5.28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.5.29
+
+- Added `onFilteredCountChanged: void Function(int count)?` to `ThemedTable2<T>`. The callback fires after every filter-and-sort cycle (initial load, search, sort, `items` update) with the count of currently visible rows. Optional and `null` by default — fully backward-compatible.
+
 ## 7.5.28
 
 - Deprecated `ThemedTable`, `ThemedColumn`, `ThemedTableAction`, `ThemedTableAvatar`, and related typedefs (`ValueBuilder`, `WidgetBuilder`, `CellTap`, `CellColor`, `ValueBuilder2`, `kThemedTableCanTrue`). Use `ThemedTable2` instead. All symbols will be removed in version 8.0.0.

--- a/lib/src/inputs/src/pickers/general/color.dart
+++ b/lib/src/inputs/src/pickers/general/color.dart
@@ -30,6 +30,10 @@ class ThemedColorPicker extends StatefulWidget {
   /// [dense] is the state of the input being dense.
   final bool dense;
 
+  /// [prefixIcon] is the prefix icon of the input.
+  @Deprecated('prefixIcon is no longer used in ThemedColorPicker')
+  final IconData? prefixIcon;
+
   /// [onPrefixTap] is the callback function when the prefix is tapped.
   final VoidCallback? onPrefixTap;
 
@@ -84,6 +88,8 @@ class ThemedColorPicker extends StatefulWidget {
     this.hideDetails = false,
     this.padding,
     this.dense = false,
+    // ignore: deprecated_member_use_from_same_package
+    this.prefixIcon,
     this.onPrefixTap,
     this.placeholder,
     this.saveText = "OK",

--- a/lib/src/table2/src/table.dart
+++ b/lib/src/table2/src/table.dart
@@ -79,6 +79,11 @@ class ThemedTable2<T> extends StatefulWidget {
   /// [controller] is an optional controller to programmatically control the table.
   final ThemedTable2Controller<T>? controller;
 
+  /// [onFilteredCountChanged] is called whenever the number of rows currently
+  /// displayed in the table changes (after filtering and sorting completes).
+  /// The integer argument is the new filtered row count.
+  final void Function(int count)? onFilteredCountChanged;
+
   const ThemedTable2({
     required this.items,
     required this.columns,
@@ -102,6 +107,7 @@ class ThemedTable2<T> extends StatefulWidget {
     this.onTapDefaultBehavior = .copyToClipboard,
     this.copyToClipboardText,
     this.controller,
+    this.onFilteredCountChanged,
   }) : assert(columns.length > 0, 'Columns cant be empty'),
        assert(actionsCount >= 0, 'Actions count cant be negative'),
        assert(minColumnWidth > 0, 'Min column width must be greater than 0'),
@@ -209,6 +215,7 @@ class _ThemedTable2State<T> extends State<ThemedTable2<T>> {
     _selectedItems.addListener(_syncSelectedSet);
 
     widget.controller?.addListener(_onControllerEvent);
+    _filteredData.addListener(_onFilteredDataChanged);
 
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _filterAndSort('INIT_STATE');
@@ -295,6 +302,7 @@ class _ThemedTable2State<T> extends State<ThemedTable2<T>> {
   @override
   void dispose() {
     _isLoading.dispose();
+    _filteredData.removeListener(_onFilteredDataChanged);
     _filteredData.dispose();
     _searchController.dispose();
 
@@ -318,6 +326,11 @@ class _ThemedTable2State<T> extends State<ThemedTable2<T>> {
     _selectedSet
       ..clear()
       ..addAll(_selectedItems.value);
+  }
+
+  /// Called when [_filteredData] changes; forwards the new count to [widget.onFilteredCountChanged].
+  void _onFilteredDataChanged() {
+    widget.onFilteredCountChanged?.call(_filteredData.value.length);
   }
 
   void _onControllerEvent(ThemedTable2Event event) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: layrz_theme
 description: Layrz standard styling library for Flutter. Widget library following the Material Design 3 guidelines, with a focus on reliavility and functionality.
-version: "7.5.28"
+version: "7.5.29"
 homepage: https://theme.layrz.com
 repository: https://github.com/goldenm-software/layrz_theme
 

--- a/test/widgets/table2_test.dart
+++ b/test/widgets/table2_test.dart
@@ -71,6 +71,7 @@ Widget _buildTable(
   List<ThemedColumn2<_Item>>? columns,
   bool canSearch = false,
   ThemedTable2Controller<_Item>? controller,
+  void Function(int count)? onFilteredCountChanged,
 }) {
   return MaterialApp(
     home: Scaffold(
@@ -84,6 +85,7 @@ Widget _buildTable(
           canSearch: canSearch,
           populateDelay: Duration.zero,
           controller: controller,
+          onFilteredCountChanged: onFilteredCountChanged,
           columns: columns ??
               [
                 ThemedColumn2<_Item>(
@@ -547,6 +549,158 @@ void main() {
           expect(find.text('EditedMiddle'), findsOneWidget);
         },
       );
+    });
+
+    // ─────────────────────────────────────────────
+    // onFilteredCountChanged
+    // ─────────────────────────────────────────────
+    group('onFilteredCountChanged', () {
+      testWidgets('fires with full count on initial load', (tester) async {
+        final counts = <int>[];
+        final items = [
+          const _Item(id: '1', name: 'Alpha', secondary: ''),
+          const _Item(id: '2', name: 'Beta', secondary: ''),
+          const _Item(id: '3', name: 'Gamma', secondary: ''),
+        ];
+
+        await tester.pumpWidget(_buildTable(items, onFilteredCountChanged: counts.add));
+        await tester.pump();
+        await _waitForCompute(tester);
+
+        expect(counts.last, equals(3));
+      });
+
+      testWidgets('null callback does not throw', (tester) async {
+        final items = [const _Item(id: '1', name: 'Alpha', secondary: '')];
+
+        await tester.pumpWidget(_buildTable(items));
+        await tester.pump();
+        await _waitForCompute(tester);
+
+        expect(tester.takeException(), isNull);
+      });
+
+      testWidgets('fires with 0 on empty items list', (tester) async {
+        final counts = <int>[];
+
+        await tester.pumpWidget(_buildTable([], onFilteredCountChanged: counts.add));
+        await tester.pump();
+        await _waitForCompute(tester);
+
+        expect(counts.last, equals(0));
+      });
+
+      testWidgets('fires filtered count after search narrows results', (tester) async {
+        final counts = <int>[];
+        final items = [
+          const _Item(id: '1', name: 'Apple', secondary: ''),
+          const _Item(id: '2', name: 'Banana', secondary: ''),
+          const _Item(id: '3', name: 'Apricot', secondary: ''),
+        ];
+
+        await tester.pumpWidget(
+          _buildTable(items, canSearch: true, onFilteredCountChanged: counts.add),
+        );
+        await tester.pump();
+        await _waitForCompute(tester);
+        expect(counts.last, equals(3));
+
+        // 'Ap' matches Apple and Apricot (both start with 'Ap'), but not Banana.
+        await tester.enterText(find.byType(TextField), 'Ap');
+        await tester.pump(const Duration(milliseconds: 700));
+        await _waitForCompute(tester);
+
+        expect(counts.last, equals(2));
+      });
+
+      testWidgets('fires updated count when items list grows via didUpdateWidget', (tester) async {
+        final counts = <int>[];
+        List<_Item> items = [const _Item(id: '1', name: 'First', secondary: '')];
+        late StateSetter rebuildState;
+
+        await tester.pumpWidget(
+          StatefulBuilder(
+            builder: (context, setState) {
+              rebuildState = setState;
+              return MaterialApp(
+                home: Scaffold(
+                  body: SizedBox(
+                    height: 600,
+                    width: 800,
+                    child: ThemedTable2<_Item>(
+                      items: items,
+                      actionsCount: 0,
+                      hasMultiselect: false,
+                      canSearch: false,
+                      populateDelay: Duration.zero,
+                      onFilteredCountChanged: counts.add,
+                      columns: [
+                        ThemedColumn2<_Item>(
+                          headerText: 'Name',
+                          valueBuilder: (item) => item.name,
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              );
+            },
+          ),
+        );
+        await tester.pump();
+        await _waitForCompute(tester);
+        expect(counts.last, equals(1));
+
+        rebuildState(() {
+          items = [
+            const _Item(id: '1', name: 'First', secondary: ''),
+            const _Item(id: '2', name: 'Second', secondary: ''),
+          ];
+        });
+        await tester.pump();
+        await _waitForCompute(tester);
+
+        expect(counts.last, equals(2));
+      });
+
+      testWidgets('fires with same count after controller.sort', (tester) async {
+        final counts = <int>[];
+        final controller = ThemedTable2Controller<_Item>();
+        addTearDown(controller.dispose);
+
+        final items = [
+          const _Item(id: '1', name: 'Zebra', secondary: ''),
+          const _Item(id: '2', name: 'Apple', secondary: ''),
+        ];
+
+        await tester.pumpWidget(
+          _buildTable(items, controller: controller, onFilteredCountChanged: counts.add),
+        );
+        await tester.pump();
+        await _waitForCompute(tester);
+        final countAfterInit = counts.last;
+
+        controller.sort(columnIndex: 0, ascending: true);
+        await _waitForCompute(tester);
+
+        expect(counts.last, equals(countAfterInit));
+        expect(counts.last, equals(2));
+      });
+
+      testWidgets('does not fire after widget is disposed', (tester) async {
+        final counts = <int>[];
+        final items = [const _Item(id: '1', name: 'Alpha', secondary: '')];
+
+        await tester.pumpWidget(_buildTable(items, onFilteredCountChanged: counts.add));
+        await tester.pump();
+        await _waitForCompute(tester);
+        final countAfterMount = counts.length;
+
+        await tester.pumpWidget(const MaterialApp(home: SizedBox.shrink()));
+        await tester.pump();
+
+        expect(counts.length, equals(countAfterMount));
+      });
     });
   });
 }


### PR DESCRIPTION
This pull request introduces version 7.5.29 of the package, focusing on two main improvements: adding a new callback to `ThemedTable2` for tracking filtered row counts, and restoring the deprecated `prefixIcon` parameter in `ThemedColorPicker` for backward compatibility. Both changes are fully backward-compatible and include updated documentation and thorough test coverage.

**Enhancements to ThemedTable2:**

* Added an optional `onFilteredCountChanged: void Function(int count)?` callback to `ThemedTable2<T>`. This callback is invoked after every filter-and-sort cycle (such as initial load, search, sort, or items update) and receives the current count of visible rows. This is useful for tracking or displaying the number of filtered items in real time. The feature is documented in the API reference, usage examples, and changelog, and is covered by comprehensive widget tests. [[1]](diffhunk://#diff-5b9ef11e8406724411bc47df7bacb49b59952951fd8bdd7628101cf5d723be40R82-R86) [[2]](diffhunk://#diff-5b9ef11e8406724411bc47df7bacb49b59952951fd8bdd7628101cf5d723be40R331-R335) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R7) [[4]](diffhunk://#diff-2549de8468a366a1e4c8a06fe3de46d9ab59dcc6e8b1dbab6367dea0d56fa8abR52) [[5]](diffhunk://#diff-2549de8468a366a1e4c8a06fe3de46d9ab59dcc6e8b1dbab6367dea0d56fa8abR134-R145) [[6]](diffhunk://#diff-fab77cddfa73987f0672c928d56c7ffca8bf0269aca45a36d00b4609f7b530c7R99) [[7]](diffhunk://#diff-fab77cddfa73987f0672c928d56c7ffca8bf0269aca45a36d00b4609f7b530c7R125) [[8]](diffhunk://#diff-7b4435231e649c70e83eea7e900d727e2696e9ba322a852a880b038815939649R74) [[9]](diffhunk://#diff-7b4435231e649c70e83eea7e900d727e2696e9ba322a852a880b038815939649R88) [[10]](diffhunk://#diff-7b4435231e649c70e83eea7e900d727e2696e9ba322a852a880b038815939649R553-R704)

**Backward Compatibility for ThemedColorPicker:**

* Restored the `prefixIcon` parameter in `ThemedColorPicker` as a deprecated property. Although this parameter was removed in a previous release, it is still referenced in downstream packages. The parameter is now accepted (but ignored), allowing dependent packages to remain build-compatible while they migrate away from using it. [[1]](diffhunk://#diff-6d3972d2aa6e3c10d8218aa081a0011d0bcabb08736741c843e4ba520c8b22eaR33-R36) [[2]](diffhunk://#diff-6d3972d2aa6e3c10d8218aa081a0011d0bcabb08736741c843e4ba520c8b22eaR91-R92) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R7)

**Versioning and Documentation:**

* Updated the package version to `7.5.29` and documented all changes in the `CHANGELOG.md` file. [[1]](diffhunk://#diff-8b7e9df87668ffa6a04b32e1769a33434999e54ae081c52e5d943c541d4c0d25L3-R3) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR3-R7)