### PR TITLE
fix(table): restore ThemedTableAvatar and CellTap<T> from incorrect d…

### DIFF
--- a/.claude/plugin.json
+++ b/.claude/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "layrz-theme",
   "description": "Claude Code skills for layrz-theme Flutter widget library",
-  "version": "7.5.28",
+  "version": "7.5.30",
   "author": {
     "name": "Golden M, Inc.",
     "url": "https://github.com/goldenm-software"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 7.5.30
+
+- Fixed incorrect deprecation of `ThemedTableAvatar`: the class is used by `ThemedScaffoldView.avatarBuilder` in the scaffolds module and is not exclusive to `ThemedTable`. Consumers using `ThemedScaffoldView` were receiving a false `deprecated_member_use` warning.
+- Fixed incorrect deprecation of `CellTap<T>`: the typedef is used by `ThemedColumn2.onTap` in `ThemedTable2` and must remain public and non-deprecated while `ThemedTable2` depends on it.
+
 ## 7.5.29
 
 - Added `onFilteredCountChanged: void Function(int count)?` to `ThemedTable2<T>`. The callback fires after every filter-and-sort cycle (initial load, search, sort, `items` update) with the count of currently visible rows. Optional and `null` by default — fully backward-compatible.

--- a/lib/src/scaffolds/src/sidebar.dart
+++ b/lib/src/scaffolds/src/sidebar.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: deprecated_member_use_from_same_package
 part of '../scaffolds.dart';
 
 class ThemedScaffoldView<T> extends StatefulWidget {

--- a/lib/src/table/src/avatar.dart
+++ b/lib/src/table/src/avatar.dart
@@ -1,6 +1,5 @@
 part of '../table.dart';
 
-@Deprecated('Use ThemedTable2 instead. ThemedTable will be removed in version 8.0.0.')
 class ThemedTableAvatar {
   /// Represents the name, label or identifier of the avatar.
   final String? label;

--- a/lib/src/table/src/column.dart
+++ b/lib/src/table/src/column.dart
@@ -9,7 +9,6 @@ typedef ValueBuilder<T> = String Function(BuildContext context, T item);
 typedef WidgetBuilder<T> = Widget Function(BuildContext context, T item);
 
 /// [CellTap<T>] defines the action when the cell is tapped.
-@Deprecated('Use ThemedTable2 instead. ThemedTable will be removed in version 8.0.0.')
 typedef CellTap<T> = void Function(T item);
 
 /// [CellColor<T>] defines the color of the cell.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: layrz_theme
 description: Layrz standard styling library for Flutter. Widget library following the Material Design 3 guidelines, with a focus on reliavility and functionality.
-version: "7.5.29"
+version: "7.5.30"
 homepage: https://theme.layrz.com
 repository: https://github.com/goldenm-software/layrz_theme
 


### PR DESCRIPTION
…eprecation

Both symbols were marked @Deprecated in 7.5.28 as part of the ThemedTable deprecation sweep, but neither is exclusive to ThemedTable:
- ThemedTableAvatar is used by ThemedScaffoldView.avatarBuilder in scaffolds/
- CellTap<T> is used by ThemedColumn2.onTap in table2/

Removed @Deprecated from both and dropped the now-unnecessary // ignore_for_file in scaffolds/src/sidebar.dart.

Bumps version to 7.5.30.