### PR TITLE
fix: Sort date pair on range close in ThemedDateTimeRangePicker

### DIFF
--- a/.claude/plugin.json
+++ b/.claude/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "layrz-theme",
   "description": "Claude Code skills for layrz-theme Flutter widget library",
-  "version": "7.5.30",
+  "version": "7.5.31",
   "author": {
     "name": "Golden M, Inc.",
     "url": "https://github.com/goldenm-software"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.5.31
+
+- Fixed `ThemedDateTimeRangePicker` swapped times when the date range was picked in reverse order: selecting the later date first and the earlier date second caused the times entered in the Time tab to be glued to the wrong endpoint, because `startDate`/`endDate` were left in selection order while only the final save sorted the resulting `DateTime`s. The dialog now sorts `startDate`/`endDate` the moment the second tap closes the range, so the Time tab always shows "Start" for the earlier day and "End" for the later one and the returned `[start, end]` list keeps each time aligned with its intended date.
+
 ## 7.5.30
 
 - Fixed incorrect deprecation of `ThemedTableAvatar`: the class is used by `ThemedScaffoldView.avatarBuilder` in the scaffolds module and is not exclusive to `ThemedTable`. Consumers using `ThemedScaffoldView` were receiving a false `deprecated_member_use` warning.

--- a/lib/src/inputs/src/pickers/datetime/range.dart
+++ b/lib/src/inputs/src/pickers/datetime/range.dart
@@ -420,11 +420,12 @@ class _ThemedDateTimeRangeDialogState extends State<ThemedDateTimeRangeDialog> w
 
                           endDate = newDate;
                           tempDate = null;
-                          filledDates = _fillDates(
-                            [startDate, endDate]..sort((a, b) {
-                              return a.compareTo(b);
-                            }),
-                          );
+                          if (endDate.isBefore(startDate)) {
+                            final swap = startDate;
+                            startDate = endDate;
+                            endDate = swap;
+                          }
+                          filledDates = _fillDates([startDate, endDate]);
                           setState(() {});
                         },
                       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: layrz_theme
 description: Layrz standard styling library for Flutter. Widget library following the Material Design 3 guidelines, with a focus on reliavility and functionality.
-version: "7.5.30"
+version: "7.5.31"
 homepage: https://theme.layrz.com
 repository: https://github.com/goldenm-software/layrz_theme
 


### PR DESCRIPTION
When the range was picked in reverse order (later day first, earlier day second), startDate/endDate were kept in selection order and only sorted at save time. Times entered in the Time tab were glued to the wrong endpoint, so the saved [start, end] list had each time pointing at the opposite date. Sort the date pair the moment the second tap closes the range, so the Time tab always shows Start = earlier day, End = later day, and each time stays aligned with its intended date.

chore: Bump version to 7.5.31 in pubspec.yaml and .claude/plugin.json
docs: Add 7.5.31 entry to CHANGELOG.md