### PR TITLE
fix: preserve horizontal layout in ResponsiveRow when spacing is grea…

### DIFF
--- a/.claude/plugin.json
+++ b/.claude/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "layrz-theme",
   "description": "Claude Code skills for layrz-theme Flutter widget library",
-  "version": "7.5.31",
+  "version": "7.5.33",
   "author": {
     "name": "Golden M, Inc.",
     "url": "https://github.com/goldenm-software"

--- a/.claude/skills/responsive-col/SKILL.md
+++ b/.claude/skills/responsive-col/SKILL.md
@@ -34,8 +34,8 @@ ResponsiveCol(
 
 - `xs` defaults to `.col12` but should always be set explicitly — it's the fallback for all other breakpoints.
 - Fallback chain: `xl ?? lg ?? md ?? sm ?? xs` — only set breakpoints that differ.
-- Uses `LayoutBuilder` internally — breakpoint is evaluated against the col's own available width, not the screen width.
-- Width formula: `(containerWidth / 12) * gridSize`.
+- Does NOT use `LayoutBuilder` internally — `build` returns `child` directly (pass-through). The breakpoint is evaluated by the parent `ResponsiveRow` via `gridSizeAt(rowWidth)`, using the row's full width (not the col's own constraint).
+- Width is assigned by the parent `ResponsiveRow` as `SizedBox(width: available * gridSize / 12)` where `available = totalWidth - spacing * (n - 1)`. The col widget itself is unaware of its width.
 
 ---
 

--- a/.claude/skills/responsive-col/references/api.md
+++ b/.claude/skills/responsive-col/references/api.md
@@ -54,8 +54,26 @@ const ResponsiveCol({
 | `xl` | `Sizes?` | `null` | ≥ 1904 px. Falls back to `lg → md → sm → xs` |
 | `child` | `Widget` | required | |
 
-Rendered via `LayoutBuilder` — breakpoint is evaluated against the col's own constraint width.  
-Width formula: `(containerWidth / 12) * gridSize`
+Rendered as a pass-through — `build` returns `child` directly (no inner `LayoutBuilder`, no `SizedBox`). The breakpoint is evaluated by the parent `ResponsiveRow` against the row's full width via the package-internal `gridSizeAt(double rowWidth)` accessor. The col's final width is computed by `ResponsiveRow` and applied via an outer `SizedBox` wrapping the col.
+
+Width formula (computed in `ResponsiveRow`, post-v7.5.33):
+
+```
+availableWidth = rowWidth − spacing × (n − 1)
+childWidth     = (availableWidth / 12) × gridSize
+```
+
+where `n` is the number of cols in the same row (cols are grouped so the sum of their `gridSize` ≤ 12 per row).
+
+---
+
+## Package-internal API
+
+```dart
+int gridSizeAt(double rowWidth)
+```
+
+Returns the `gridSize` (1–12) that this col resolves to at the given row width, applying the breakpoint fallback chain (`xl ?? lg ?? md ?? sm ?? xs`). Called by `ResponsiveRow` during layout — not intended for direct use, but visible because the col is not in a private library.
 
 ---
 

--- a/.claude/skills/responsive-row/SKILL.md
+++ b/.claude/skills/responsive-row/SKILL.md
@@ -34,10 +34,10 @@ ResponsiveRow(
 
 ## Key behaviors
 
-- Renders as `SizedBox(width: double.infinity, child: Wrap(...))` — always full parent width.
+- Renders as `SizedBox(width: double.infinity, child: LayoutBuilder(...))` — uses a Column of Rows internally; LayoutBuilder provides the total row width for per-child sizing calculations. The internal Wrap-based implementation was replaced in v7.5.33 to enforce true gaps.
 - `children` only accepts `List<ResponsiveCol>` — use `ResponsiveCol(child: Divider())` for dividers.
 - `builder` takes `ResponsiveCol Function(int)` — not `Widget Function(BuildContext, int)`.
-- `spacing` applies to **both axes**: horizontal gap between columns in the same row, and vertical gap between rows when columns wrap (default `0`).
+- `spacing` applies to **both axes**: horizontal gap between columns in the same row, and vertical gap between rows when columns wrap (default `0`). As of v7.5.33, spacing is a TRUE pixel gap: `availableWidth = totalWidth - spacing * (n - 1)`, then each child's width = `(availableWidth / 12) * gridSize`. Two col6 children with spacing=12 each receive `(totalWidth - 12) / 2` pixels — not `totalWidth / 2 - 6`.
 
 ---
 
@@ -66,4 +66,29 @@ ResponsiveRow.builder(
     child: ItemCard(item: items[index]),
   ),
 )
+
+// Fully responsive breakpoint reflow — 1/2/3/4 cols across breakpoints
+ResponsiveRow(
+  spacing: 12,
+  children: [
+    for (final item in items)
+      ResponsiveCol(
+        xs: .col12,  // mobile: 1 column
+        sm: .col6,   // small: 2 columns
+        md: .col4,   // medium: 3 columns
+        lg: .col3,   // large: 4 columns
+        child: ItemCard(item: item),
+      ),
+  ],
+)
 ```
+
+---
+
+## Pitfalls
+
+- **Do not place `ResponsiveCol` outside a `ResponsiveRow`.** It renders as a pass-through and will receive whatever width its parent provides, which is almost never correct.
+- **Do not wrap `ResponsiveRow` in an unbounded-width parent** (e.g. a horizontal `ListView`). The row needs a finite width to compute gridSize.
+- **`children` only accepts `List<ResponsiveCol>`.** Raw widgets won't compile. For dividers/spacers use `const ResponsiveCol(child: Divider())`.
+- **Spacing > 0 is a TRUE gap — it does NOT reduce each child's gridSize.** Two `.col6` with `spacing: 12` fit on one row; the gap is carved from `totalWidth` before distributing the 12-column grid.
+- **Do not nest `ResponsiveRow` inside another `ResponsiveRow`** without awareness that spacing is applied per-row independently.

--- a/.claude/skills/responsive-row/references/api.md
+++ b/.claude/skills/responsive-row/references/api.md
@@ -37,7 +37,32 @@ ResponsiveRow.builder({
 | `crossAxisAlignment` | `WrapCrossAlignment` | `.start` | Vertical alignment of columns |
 | `spacing` | `double` | `0` | Gap between columns (horizontal) and between wrapped rows (vertical) in pixels |
 
-Renders as `SizedBox(width: double.infinity, child: Wrap(...))` — always full parent width.
+Renders as `SizedBox(width: double.infinity, child: LayoutBuilder(...))`. Internally produces a Column of Rows; spacing creates true pixel gaps. See the Algorithm section below for details.
+
+---
+
+## Algorithm (post-v7.5.33)
+
+`ResponsiveRow` replaces the old `Wrap`-based layout with a deterministic two-pass algorithm:
+
+**Step 1 — Row grouping**
+Children are walked in order. Each child's `gridSizeAt(totalWidth)` is accumulated. When adding the next child would make the running sum exceed 12, a new row begins. This guarantees predictable row breaks (e.g. col6+col6 fills one row; adding a col4 starts a second row).
+
+**Step 2 — Width calculation**
+For a row containing *n* children:
+```
+available = totalWidth - spacing * (n - 1)
+childWidth = available * gridSize / 12
+```
+Each child is wrapped in `SizedBox(width: childWidth)`. Horizontal `SizedBox(width: spacing)` widgets are interleaved between siblings.
+
+**Step 3 — Vertical gap**
+`SizedBox(height: spacing)` is inserted between consecutive rows.
+
+**Step 4 — Alignment mapping**
+`mainAxisAlignment` (`WrapAlignment`) maps to `MainAxisAlignment`; `crossAxisAlignment` (`WrapCrossAlignment`) maps to `CrossAxisAlignment` — the property names are kept for backwards compatibility.
+
+**`gridSizeAt(double rowWidth)`** is a package-internal method on `ResponsiveCol`, called by `ResponsiveRow._groupIntoRows` and `ResponsiveRow._buildRow`. It returns the active grid column count (1–12) for the given parent row width. It is not part of the public widget API and should not be called by application code.
 
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -53,5 +53,6 @@ ignoreme.dart
 
 # Claude Code
 .claude/settings.local.json
+.atl/
 
 coverage/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 7.5.33
+
+- fix: preserve horizontal layout in `ResponsiveRow` when `spacing > 0` and child gridSizes sum to 12 (e.g., two `col6`, three `col4`). Render path now uses a single `LayoutBuilder` with explicit per-row sizing; public API unchanged.
+- behavior note: when `spacing > 0`, each child's pixel width is now computed as `(totalWidth - spacing * (n - 1)) / 12 * gridSize` (where `n` is the number of children in that row). Previously each child computed its width as `totalWidth / 12 * gridSize` ignoring spacing, which caused the wrap bug. Consumers with golden tests or pixel-perfect layouts that use `spacing > 0` may see small width differences (e.g. 500px → 494px for a `col6` with `spacing: 12` and two children). Layouts with `spacing: 0` are pixel-identical to previous versions.
+- internal: `ResponsiveCol.build` now returns `child` directly (no inner `LayoutBuilder`); breakpoint resolution is delegated to the parent `ResponsiveRow` via the new package-internal accessor `ResponsiveCol.gridSizeAt(double rowWidth)`. `ResponsiveCol` was always documented as a child of `ResponsiveRow`; standalone usage was never supported.
+- example: added a dedicated `ResponsiveRowShowcaseView` at `/grid/responsive-row` with 8 interactive cases (basic two-column, three-column with tunable spacing via `ThemedNumberInput`, mixed grids, full responsive reflow, vertical gap, builder, form layout, and `crossAxisAlignment` toggle). Accessible from the sidebar and the home view.
+- skills: updated `responsive-row` and `responsive-col` skills with the post-7.5.33 render path, the per-row width formula, the row-grouping algorithm, and the new `gridSizeAt` accessor.
+
 ## 7.5.32
 
 - Added `onSort`, `onSearch` and `search` to `ThemedTable2Controller` to allow programmatic control of sorting and searching, and to expose the current search query.

--- a/example/lib/router.dart
+++ b/example/lib/router.dart
@@ -14,6 +14,7 @@ import 'package:layrz_theme_example/views/not_found.dart';
 import 'package:layrz_theme_example/views/table/table.dart';
 import 'package:layrz_theme_example/views/theme_generation.dart';
 import 'package:layrz_theme_example/views/snackbars/snackbars.dart';
+import 'package:layrz_theme_example/views/grid/responsive_row.dart';
 import 'package:layrz_theme_example/views/tabs/tabs.dart';
 
 Page<void> customTransitionBuilder(BuildContext context, GoRouterState state, Widget child) {
@@ -150,6 +151,17 @@ final goRoutes = [
   GoRoute(
     path: '/map/layer',
     pageBuilder: (context, state) => customTransitionBuilder(context, state, const MapLayerView()),
+  ),
+
+  // Grid
+  GoRoute(
+    path: '/grid',
+    redirect: (context, state) => '/grid/responsive-row',
+  ),
+  GoRoute(
+    path: '/grid/responsive-row',
+    pageBuilder: (context, state) =>
+        customTransitionBuilder(context, state, const ResponsiveRowShowcaseView()),
   ),
 
   // Colorblind mode

--- a/example/lib/store/wrapper.dart
+++ b/example/lib/store/wrapper.dart
@@ -213,6 +213,11 @@ class _LayoutState extends State<Layout> {
           path: '/alerts',
           icon: LayrzIcons.solarOutlineDanger,
         ),
+        ThemedNavigatorPage(
+          labelText: 'Responsive Row & Col',
+          path: '/grid/responsive-row',
+          icon: LayrzIcons.solarOutlineWidget2,
+        ),
       ],
       persistentItems: [
         ThemedNavigatorAction(

--- a/example/lib/views/grid/responsive_row.dart
+++ b/example/lib/views/grid/responsive_row.dart
@@ -1,0 +1,515 @@
+import 'package:flutter/material.dart';
+import 'package:layrz_theme/layrz_theme.dart';
+import 'package:layrz_theme_example/store/store.dart';
+
+class ResponsiveRowShowcaseView extends StatefulWidget {
+  const ResponsiveRowShowcaseView({super.key});
+
+  @override
+  State<ResponsiveRowShowcaseView> createState() => _ResponsiveRowShowcaseViewState();
+}
+
+class _ResponsiveRowShowcaseViewState extends State<ResponsiveRowShowcaseView> {
+  // Case B — adjustable spacing
+  double _spacing = 12;
+
+  // Case F — adjustable itemCount
+  int _itemCount = 4;
+
+  // Case G — form state
+  String _firstName = '';
+  String _lastName = '';
+
+  // Case H — crossAxisAlignment
+  CrossAxisAlignment _alignment = CrossAxisAlignment.start;
+
+  // ── Case A ─────────────────────────────────────────────────────────────
+  Widget _caseA() {
+    return ResponsiveRow(
+      spacing: 12,
+      children: [
+        ResponsiveCol(
+          xs: .col12,
+          md: .col6,
+          child: _DemoBox(color: Colors.blue, label: 'col6'),
+        ),
+        ResponsiveCol(
+          xs: .col12,
+          md: .col6,
+          child: _DemoBox(color: Colors.orange, label: 'col6'),
+        ),
+      ],
+    );
+  }
+
+  // ── Case B ─────────────────────────────────────────────────────────────
+  Widget _caseB() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('spacing: ${_spacing.toStringAsFixed(1)} px'),
+        Slider(
+          value: _spacing,
+          min: 0,
+          max: 32,
+          divisions: 32,
+          label: _spacing.toStringAsFixed(0),
+          onChanged: (v) => setState(() => _spacing = v),
+        ),
+        ResponsiveRow(
+          spacing: _spacing,
+          children: [
+            ResponsiveCol(
+              xs: .col12,
+              sm: .col4,
+              child: _DemoBox(color: Colors.green, label: 'col4'),
+            ),
+            ResponsiveCol(
+              xs: .col12,
+              sm: .col4,
+              child: _DemoBox(color: Colors.teal, label: 'col4'),
+            ),
+            ResponsiveCol(
+              xs: .col12,
+              sm: .col4,
+              child: _DemoBox(color: Colors.cyan, label: 'col4'),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  // ── Case C ─────────────────────────────────────────────────────────────
+  Widget _caseC() {
+    return ResponsiveRow(
+      spacing: 8,
+      children: [
+        ResponsiveCol(
+          xs: .col12,
+          md: .col6,
+          child: _DemoBox(color: Colors.purple, label: 'col6 (row 1)'),
+        ),
+        ResponsiveCol(
+          xs: .col12,
+          md: .col6,
+          child: _DemoBox(color: Colors.deepPurple, label: 'col6 (row 1)'),
+        ),
+        ResponsiveCol(
+          xs: .col12,
+          md: .col4,
+          child: _DemoBox(color: Colors.pink, label: 'col4 (row 2)'),
+        ),
+        ResponsiveCol(
+          xs: .col12,
+          md: .col4,
+          child: _DemoBox(color: Colors.red, label: 'col4 (row 2)'),
+        ),
+        ResponsiveCol(
+          xs: .col12,
+          md: .col4,
+          child: _DemoBox(color: Colors.deepOrange, label: 'col4 (row 2)'),
+        ),
+      ],
+    );
+  }
+
+  // ── Case D ─────────────────────────────────────────────────────────────
+  Widget _caseD() {
+    final colors = [Colors.indigo, Colors.blue, Colors.lightBlue, Colors.cyan];
+    return ResponsiveRow(
+      spacing: 8,
+      children: [
+        for (final c in colors)
+          ResponsiveCol(
+            xs: .col12,
+            sm: .col6,
+            md: .col4,
+            lg: .col3,
+            child: _DemoBox(color: c, label: 'xs=12 sm=6 md=4 lg=3'),
+          ),
+      ],
+    );
+  }
+
+  // ── Case E ─────────────────────────────────────────────────────────────
+  Widget _caseE() {
+    return ResponsiveRow(
+      spacing: 20,
+      children: [
+        ResponsiveCol(
+          xs: .col12,
+          child: _DemoBox(color: Colors.amber, label: 'col12 (item 1)'),
+        ),
+        ResponsiveCol(
+          xs: .col12,
+          child: _DemoBox(color: Colors.orange, label: 'col12 (item 2)'),
+        ),
+        ResponsiveCol(
+          xs: .col12,
+          child: _DemoBox(color: Colors.deepOrange, label: 'col12 (item 3)'),
+        ),
+      ],
+    );
+  }
+
+  // ── Case F ─────────────────────────────────────────────────────────────
+  Widget _caseF() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        ThemedNumberInput(
+          labelText: 'itemCount',
+          value: _itemCount,
+          minimum: 1,
+          maximum: 6,
+          step: 1,
+          maximumDecimalDigits: 0,
+          onChanged: (v) => setState(() => _itemCount = (v ?? 1).toInt().clamp(1, 6)),
+        ),
+        const SizedBox(height: 12),
+        ResponsiveRow.builder(
+          spacing: 8,
+          itemCount: _itemCount,
+          itemBuilder: (index) => ResponsiveCol(
+            xs: .col12,
+            sm: .col6,
+            md: .col4,
+            child: _DemoBox(
+              color: Colors.primaries[index % Colors.primaries.length],
+              label: 'Item ${index + 1}',
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  // ── Case G ─────────────────────────────────────────────────────────────
+  Widget _caseG() {
+    return ResponsiveRow(
+      spacing: 12,
+      children: [
+        ResponsiveCol(
+          xs: .col12,
+          md: .col6,
+          child: ThemedTextInput(
+            labelText: 'First name',
+            value: _firstName,
+            onChanged: (v) => setState(() => _firstName = v),
+          ),
+        ),
+        ResponsiveCol(
+          xs: .col12,
+          md: .col6,
+          child: ThemedTextInput(
+            labelText: 'Last name',
+            value: _lastName,
+            onChanged: (v) => setState(() => _lastName = v),
+          ),
+        ),
+      ],
+    );
+  }
+
+  // ── Case H ─────────────────────────────────────────────────────────────
+  Widget _caseH() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        DropdownButton<CrossAxisAlignment>(
+          value: _alignment,
+          items: const [
+            DropdownMenuItem(value: CrossAxisAlignment.start, child: Text('CrossAxisAlignment.start')),
+            DropdownMenuItem(value: CrossAxisAlignment.center, child: Text('CrossAxisAlignment.center')),
+            DropdownMenuItem(value: CrossAxisAlignment.end, child: Text('CrossAxisAlignment.end')),
+          ],
+          onChanged: (v) => setState(() => _alignment = v ?? CrossAxisAlignment.start),
+        ),
+        const SizedBox(height: 8),
+        ResponsiveRow(
+          spacing: 8,
+          crossAxisAlignment: _alignment == CrossAxisAlignment.start
+              ? WrapCrossAlignment.start
+              : _alignment == CrossAxisAlignment.center
+                  ? WrapCrossAlignment.center
+                  : WrapCrossAlignment.end,
+          children: [
+            ResponsiveCol(
+              xs: .col12,
+              sm: .col4,
+              child: _DemoBox(color: Colors.red, label: 'h=80', height: 80),
+            ),
+            ResponsiveCol(
+              xs: .col12,
+              sm: .col4,
+              child: _DemoBox(color: Colors.green, label: 'h=130', height: 130),
+            ),
+            ResponsiveCol(
+              xs: .col12,
+              sm: .col4,
+              child: _DemoBox(color: Colors.blue, label: 'h=100', height: 100),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Layout(
+      body: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: [
+          Text(
+            'Responsive Grid',
+            style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 10),
+          Expanded(
+            child: ListView(
+              padding: const EdgeInsets.all(10),
+              children: [
+                _SectionCard(
+                  title: 'Case A: 2× col6 with spacing > 0',
+                  caption: 'Two half-width columns with a 12 px true gap — at md+ they appear side-by-side.',
+                  demo: _caseA(),
+                  code: r'''
+ResponsiveRow(
+  spacing: 12,
+  children: [
+    ResponsiveCol(xs: .col12, md: .col6, child: WidgetA()),
+    ResponsiveCol(xs: .col12, md: .col6, child: WidgetB()),
+  ],
+)''',
+                ),
+                _SectionCard(
+                  title: 'Case B: 3× col4 with tunable spacing',
+                  caption: 'Drag the slider to see how a TRUE gap shrinks each column width proportionally.',
+                  demo: _caseB(),
+                  code: r'''
+ResponsiveRow(
+  spacing: spacing,  // double, 0–32
+  children: [
+    ResponsiveCol(xs: .col12, sm: .col4, child: WidgetA()),
+    ResponsiveCol(xs: .col12, sm: .col4, child: WidgetB()),
+    ResponsiveCol(xs: .col12, sm: .col4, child: WidgetC()),
+  ],
+)''',
+                ),
+                _SectionCard(
+                  title: 'Case C: Mixed grid (col6+col6 / col4+col4+col4)',
+                  caption: 'Five children grouped into two visual rows at md+: first two share a row (col6), then three share the next (col4).',
+                  demo: _caseC(),
+                  code: r'''
+ResponsiveRow(
+  spacing: 8,
+  children: [
+    ResponsiveCol(xs: .col12, md: .col6, child: WidgetA()),  // row 1
+    ResponsiveCol(xs: .col12, md: .col6, child: WidgetB()),  // row 1
+    ResponsiveCol(xs: .col12, md: .col4, child: WidgetC()),  // row 2
+    ResponsiveCol(xs: .col12, md: .col4, child: WidgetD()),  // row 2
+    ResponsiveCol(xs: .col12, md: .col4, child: WidgetE()),  // row 2
+  ],
+)''',
+                ),
+                _SectionCard(
+                  title: 'Case D: Fully responsive breakpoint reflow',
+                  caption: 'xs=1 col, sm=2 cols, md=3 cols, lg=4 cols — resize the window to see the grid reflow.',
+                  demo: _caseD(),
+                  code: r'''
+ResponsiveRow(
+  spacing: 8,
+  children: [
+    for (final item in items)
+      ResponsiveCol(
+        xs: .col12,  // 1 column on mobile
+        sm: .col6,   // 2 columns on small screens
+        md: .col4,   // 3 columns on medium screens
+        lg: .col3,   // 4 columns on large screens
+        child: ItemWidget(item),
+      ),
+  ],
+)''',
+                ),
+                _SectionCard(
+                  title: 'Case E: Stacked col12 with vertical gap',
+                  caption: 'Three full-width rows with spacing: 20 — vertical SizedBox(height: 20) is inserted between each row.',
+                  demo: _caseE(),
+                  code: r'''
+ResponsiveRow(
+  spacing: 20,
+  children: [
+    ResponsiveCol(xs: .col12, child: WidgetA()),
+    ResponsiveCol(xs: .col12, child: WidgetB()),
+    ResponsiveCol(xs: .col12, child: WidgetC()),
+  ],
+)''',
+                ),
+                _SectionCard(
+                  title: 'Case F: ResponsiveRow.builder with dynamic itemCount',
+                  caption: 'Use the .builder constructor to generate cols from a list. Use the ThemedNumberInput to change the count (1–6).',
+                  demo: _caseF(),
+                  code: r'''
+ResponsiveRow.builder(
+  spacing: 8,
+  itemCount: itemCount,  // 1..6
+  itemBuilder: (index) => ResponsiveCol(
+    xs: .col12,
+    sm: .col6,
+    md: .col4,
+    child: ItemCard(items[index]),
+  ),
+)''',
+                ),
+                _SectionCard(
+                  title: 'Case G: Responsive form layout',
+                  caption: 'Two form fields side-by-side at md+, stacked on mobile. The classic two-column form pattern.',
+                  demo: _caseG(),
+                  code: r'''
+ResponsiveRow(
+  spacing: 12,
+  children: [
+    ResponsiveCol(
+      xs: .col12,
+      md: .col6,
+      child: ThemedTextInput(
+        labelText: 'First name',
+        value: firstName,
+        onChanged: (v) => setState(() => firstName = v),
+      ),
+    ),
+    ResponsiveCol(
+      xs: .col12,
+      md: .col6,
+      child: ThemedTextInput(
+        labelText: 'Last name',
+        value: lastName,
+        onChanged: (v) => setState(() => lastName = v),
+      ),
+    ),
+  ],
+)''',
+                ),
+                _SectionCard(
+                  title: 'Case H: crossAxisAlignment with mixed-height children',
+                  caption: 'Use the dropdown to toggle start / center / end alignment of columns with different heights.',
+                  demo: _caseH(),
+                  code: r'''
+ResponsiveRow(
+  spacing: 8,
+  crossAxisAlignment: WrapCrossAlignment.center,  // .start | .center | .end
+  children: [
+    ResponsiveCol(xs: .col12, sm: .col4, child: SizedBox(height: 80,  child: ColorBox())),
+    ResponsiveCol(xs: .col12, sm: .col4, child: SizedBox(height: 130, child: ColorBox())),
+    ResponsiveCol(xs: .col12, sm: .col4, child: SizedBox(height: 100, child: ColorBox())),
+  ],
+)''',
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// ── Private helpers ─────────────────────────────────────────────────────────
+
+class _SectionCard extends StatelessWidget {
+  final String title;
+  final String caption;
+  final Widget demo;
+  final String code;
+
+  const _SectionCard({
+    required this.title,
+    required this.caption,
+    required this.demo,
+    required this.code,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      margin: const EdgeInsets.only(bottom: 16),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              title,
+              style: theme.textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 4),
+            Text(caption, style: theme.textTheme.bodySmall),
+            const SizedBox(height: 12),
+            demo,
+            const SizedBox(height: 12),
+            _CodeBlock(code: code),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DemoBox extends StatelessWidget {
+  final Color color;
+  final String label;
+  final double height;
+
+  const _DemoBox({
+    required this.color,
+    required this.label,
+    this.height = 60,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: height,
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.8),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      alignment: Alignment.center,
+      child: Text(
+        label,
+        style: const TextStyle(color: Colors.white, fontWeight: FontWeight.bold, fontSize: 12),
+        textAlign: TextAlign.center,
+      ),
+    );
+  }
+}
+
+class _CodeBlock extends StatelessWidget {
+  final String code;
+
+  const _CodeBlock({required this.code});
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: isDark ? Colors.grey[900] : Colors.grey[100],
+        borderRadius: BorderRadius.circular(6),
+        border: Border.all(color: isDark ? Colors.grey[700]! : Colors.grey[300]!),
+      ),
+      child: SelectableText(
+        code.trim(),
+        style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+      ),
+    );
+  }
+}

--- a/example/lib/views/home.dart
+++ b/example/lib/views/home.dart
@@ -180,6 +180,30 @@ class _HomeViewState extends State<HomeView> {
                       onTap: () => context.go('/layo'),
                     ),
                   ),
+                  const Divider(),
+                  ListTile(
+                    leading: ThemedAvatar(
+                      icon: LayrzIcons.mdiGrid,
+                      color: color,
+                      size: iconSize,
+                    ),
+                    title: Text(
+                      "Responsive Grid",
+                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.bold),
+                    ),
+                    subtitle: Text(
+                      "A 12-column responsive grid built on ResponsiveRow and ResponsiveCol. "
+                      "Eight live cases prove the v7.5.33 true-gap spacing fix and breakpoint reflow behavior.",
+                      style: Theme.of(context).textTheme.bodyMedium,
+                      maxLines: 5,
+                    ),
+                    trailing: ThemedButton(
+                      labelText: "Go!",
+                      icon: LayrzIcons.mdiRocketLaunch,
+                      color: Colors.green,
+                      onTap: () => context.go('/grid/responsive-row'),
+                    ),
+                  ),
                 ],
               ),
             ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -390,7 +390,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "7.5.31"
+    version: "7.5.33"
   leak_tracker:
     dependency: transitive
     description:

--- a/lib/src/grid/src/col.dart
+++ b/lib/src/grid/src/col.dart
@@ -34,16 +34,11 @@ class ResponsiveCol extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        return SizedBox(
-          width: _currentSize(width: constraints.maxWidth).boxWidth(constraints.maxWidth),
-          child: child,
-        );
-      },
-    );
-  }
+  Widget build(BuildContext context) => child;
+
+  /// Returns the grid column count (1..12) for this column at the given parent row width.
+  /// Used by [ResponsiveRow] to compute per-child pixel widths.
+  int gridSizeAt(double rowWidth) => _currentSize(width: rowWidth).gridSize;
 
   Sizes _currentSize({required double width}) {
     if (width < kExtraSmallGrid) {

--- a/lib/src/grid/src/row.dart
+++ b/lib/src/grid/src/row.dart
@@ -64,14 +64,89 @@ class ResponsiveRow extends StatelessWidget {
   Widget build(BuildContext context) {
     return SizedBox(
       width: double.infinity,
-      child: Wrap(
-        spacing: spacing,
-        runSpacing: spacing,
-        direction: Axis.horizontal,
-        alignment: mainAxisAlignment,
-        crossAxisAlignment: crossAxisAlignment,
-        children: children,
+      child: LayoutBuilder(
+        builder: (context, constraints) => _renderRows(constraints.maxWidth),
       ),
     );
   }
+
+  /// Orchestrates row rendering. Returns a shrink widget for empty children,
+  /// otherwise a [Column] of [Row]s interleaved with vertical gap [SizedBox]es.
+  Widget _renderRows(double totalWidth) {
+    if (children.isEmpty) return const SizedBox.shrink();
+
+    final groups = _groupIntoRows(children, totalWidth);
+    final widgets = <Widget>[];
+
+    for (var i = 0; i < groups.length; i++) {
+      if (i > 0) widgets.add(SizedBox(height: spacing));
+      widgets.add(_buildRow(groups[i], totalWidth));
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: widgets,
+    );
+  }
+
+  /// Groups [cols] into logical rows where each row's sum of gridSizes is ≤ 12.
+  /// A new row starts whenever adding the next child would push the sum above 12.
+  List<List<ResponsiveCol>> _groupIntoRows(List<ResponsiveCol> cols, double totalWidth) {
+    final rows = <List<ResponsiveCol>>[];
+    var current = <ResponsiveCol>[];
+    var sum = 0;
+
+    for (final col in cols) {
+      final g = col.gridSizeAt(totalWidth);
+      if (sum + g > 12 && current.isNotEmpty) {
+        rows.add(current);
+        current = [];
+        sum = 0;
+      }
+      current.add(col);
+      sum += g;
+    }
+
+    if (current.isNotEmpty) rows.add(current);
+    return rows;
+  }
+
+  /// Builds a single [Row] for a group of [ResponsiveCol] children.
+  /// Each child is wrapped in a [SizedBox] sized by the per-row math:
+  /// `available = totalWidth - spacing * (n - 1)`, `childWidth = available * gridSize / 12`.
+  Widget _buildRow(List<ResponsiveCol> rowCols, double totalWidth) {
+    final n = rowCols.length;
+    final available = totalWidth - spacing * (n - 1);
+    final rowChildren = <Widget>[];
+
+    for (var i = 0; i < n; i++) {
+      if (i > 0) rowChildren.add(SizedBox(width: spacing));
+      final g = rowCols[i].gridSizeAt(totalWidth);
+      rowChildren.add(SizedBox(width: available * g / 12, child: rowCols[i]));
+    }
+
+    return Row(
+      mainAxisAlignment: _mapMain(mainAxisAlignment),
+      crossAxisAlignment: _mapCross(crossAxisAlignment),
+      children: rowChildren,
+    );
+  }
+
+  /// Maps [WrapAlignment] to [MainAxisAlignment] exhaustively.
+  MainAxisAlignment _mapMain(WrapAlignment a) => switch (a) {
+        WrapAlignment.start => MainAxisAlignment.start,
+        WrapAlignment.end => MainAxisAlignment.end,
+        WrapAlignment.center => MainAxisAlignment.center,
+        WrapAlignment.spaceBetween => MainAxisAlignment.spaceBetween,
+        WrapAlignment.spaceAround => MainAxisAlignment.spaceAround,
+        WrapAlignment.spaceEvenly => MainAxisAlignment.spaceEvenly,
+      };
+
+  /// Maps [WrapCrossAlignment] to [CrossAxisAlignment] exhaustively.
+  CrossAxisAlignment _mapCross(WrapCrossAlignment a) => switch (a) {
+        WrapCrossAlignment.start => CrossAxisAlignment.start,
+        WrapCrossAlignment.center => CrossAxisAlignment.center,
+        WrapCrossAlignment.end => CrossAxisAlignment.end,
+      };
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: layrz_theme
 description: Layrz standard styling library for Flutter. Widget library following the Material Design 3 guidelines, with a focus on reliavility and functionality.
-version: "7.5.32"
+version: "7.5.33"
 homepage: https://theme.layrz.com
 repository: https://github.com/goldenm-software/layrz_theme
 

--- a/test/widgets/responsive_row_test.dart
+++ b/test/widgets/responsive_row_test.dart
@@ -5,6 +5,9 @@ import 'package:layrz_theme/layrz_theme.dart';
 void main() {
   group('ResponsiveRow', () {
     testWidgets('Renders basic ResponsiveRow with children', (WidgetTester tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      addTearDown(tester.view.resetPhysicalSize);
+
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -18,12 +21,12 @@ void main() {
         ),
       );
 
-      expect(find.byType(Wrap), findsOneWidget);
+      expect(find.byType(LayoutBuilder), findsWidgets);
       expect(find.byType(ResponsiveCol), findsNWidgets(2));
       expect(find.byType(Container), findsNWidgets(2));
     });
 
-    testWidgets('ResponsiveRow with empty children renders empty Wrap', (WidgetTester tester) async {
+    testWidgets('ResponsiveRow with empty children renders no Row widget', (WidgetTester tester) async {
       await tester.pumpWidget(
         const MaterialApp(
           home: Scaffold(
@@ -34,9 +37,8 @@ void main() {
         ),
       );
 
-      final wrap = find.byType(Wrap);
-      expect(wrap, findsOneWidget);
       expect(find.byType(ResponsiveCol), findsNothing);
+      expect(find.byType(Row), findsNothing);
     });
 
     testWidgets('ResponsiveRow with single child', (WidgetTester tester) async {
@@ -56,100 +58,127 @@ void main() {
       expect(find.byType(Container), findsOneWidget);
     });
 
-    testWidgets('ResponsiveRow respects spacing parameter', (WidgetTester tester) async {
+    testWidgets('ResponsiveRow respects spacing parameter (geometric)', (WidgetTester tester) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 800));
+      addTearDown(tester.view.resetPhysicalSize);
+
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
             body: ResponsiveRow(
               spacing: 16,
               children: [
-                ResponsiveCol(xs: .col6, child: Container(color: Colors.red, height: 100)),
-                ResponsiveCol(xs: .col6, child: Container(color: Colors.blue, height: 100)),
+                ResponsiveCol(xs: .col6, child: Container(color: Colors.red, height: 100, key: const Key('a'))),
+                ResponsiveCol(xs: .col6, child: Container(color: Colors.blue, height: 100, key: const Key('b'))),
               ],
             ),
           ),
         ),
       );
 
-      final wrap = find.byType(Wrap).evaluate().first.widget as Wrap;
-      expect(wrap.spacing, 16);
+      final aRight = tester.getTopRight(find.byKey(const Key('a')));
+      final bLeft = tester.getTopLeft(find.byKey(const Key('b')));
+      // Gap between right edge of 'a' and left edge of 'b' should equal spacing (16)
+      expect(bLeft.dx - aRight.dx, closeTo(16, 1));
     });
 
-    testWidgets('ResponsiveRow respects spacing = 0', (WidgetTester tester) async {
+    testWidgets('ResponsiveRow respects spacing = 0 (geometric)', (WidgetTester tester) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 800));
+      addTearDown(tester.view.resetPhysicalSize);
+
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
             body: ResponsiveRow(
               spacing: 0,
               children: [
-                ResponsiveCol(xs: .col6, child: Container(color: Colors.red, height: 100)),
-                ResponsiveCol(xs: .col6, child: Container(color: Colors.blue, height: 100)),
+                ResponsiveCol(xs: .col6, child: Container(color: Colors.red, height: 100, key: const Key('a'))),
+                ResponsiveCol(xs: .col6, child: Container(color: Colors.blue, height: 100, key: const Key('b'))),
               ],
             ),
           ),
         ),
       );
 
-      final wrap = find.byType(Wrap).evaluate().first.widget as Wrap;
-      expect(wrap.spacing, 0);
+      final aRight = tester.getTopRight(find.byKey(const Key('a')));
+      final bLeft = tester.getTopLeft(find.byKey(const Key('b')));
+      // With spacing=0 children are adjacent
+      expect(bLeft.dx - aRight.dx, closeTo(0, 1));
     });
 
-    testWidgets('ResponsiveRow default spacing is 0', (WidgetTester tester) async {
+    testWidgets('ResponsiveRow default spacing is 0 (geometric)', (WidgetTester tester) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 800));
+      addTearDown(tester.view.resetPhysicalSize);
+
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
             body: ResponsiveRow(
               children: [
-                ResponsiveCol(xs: .col6, child: Container(height: 100)),
-                ResponsiveCol(xs: .col6, child: Container(height: 100)),
+                ResponsiveCol(xs: .col6, child: Container(height: 100, key: const Key('a'))),
+                ResponsiveCol(xs: .col6, child: Container(height: 100, key: const Key('b'))),
               ],
             ),
           ),
         ),
       );
 
-      final wrap = find.byType(Wrap).evaluate().first.widget as Wrap;
-      expect(wrap.spacing, 0); // Default spacing should be 0
+      final aRight = tester.getTopRight(find.byKey(const Key('a')));
+      final bLeft = tester.getTopLeft(find.byKey(const Key('b')));
+      expect(bLeft.dx - aRight.dx, closeTo(0, 1));
     });
 
-    testWidgets('ResponsiveRow spacing applies to Wrap.runSpacing', (WidgetTester tester) async {
+    testWidgets('ResponsiveRow spacing applies as vertical gap between wrapped rows', (WidgetTester tester) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 800));
+      addTearDown(tester.view.resetPhysicalSize);
+
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
             body: ResponsiveRow(
               spacing: 20,
               children: [
-                ResponsiveCol(xs: .col6, child: Container(height: 100)),
-                ResponsiveCol(xs: .col6, child: Container(height: 100)),
+                ResponsiveCol(xs: .col6, child: Container(height: 100, key: const Key('a'))),
+                ResponsiveCol(xs: .col6, child: Container(height: 100, key: const Key('b'))),
+                ResponsiveCol(xs: .col6, child: Container(height: 100, key: const Key('c'))),
+                ResponsiveCol(xs: .col6, child: Container(height: 100, key: const Key('d'))),
               ],
             ),
           ),
         ),
       );
 
-      final wrap = find.byType(Wrap).evaluate().first.widget as Wrap;
-      expect(wrap.runSpacing, 20);
+      final aBottom = tester.getBottomLeft(find.byKey(const Key('a')));
+      final cTop = tester.getTopLeft(find.byKey(const Key('c')));
+      // Vertical gap between row 1 bottom and row 2 top should equal spacing
+      expect(cTop.dy - aBottom.dy, closeTo(20, 1));
     });
 
-    testWidgets('ResponsiveRow default spacing gives runSpacing of 0', (WidgetTester tester) async {
+    testWidgets('ResponsiveRow default spacing gives no vertical gap between rows', (WidgetTester tester) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 800));
+      addTearDown(tester.view.resetPhysicalSize);
+
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
             body: ResponsiveRow(
               children: [
-                ResponsiveCol(xs: .col6, child: Container(height: 100)),
-                ResponsiveCol(xs: .col6, child: Container(height: 100)),
+                ResponsiveCol(xs: .col6, child: Container(height: 100, key: const Key('a'))),
+                ResponsiveCol(xs: .col6, child: Container(height: 100, key: const Key('b'))),
+                ResponsiveCol(xs: .col6, child: Container(height: 100, key: const Key('c'))),
+                ResponsiveCol(xs: .col6, child: Container(height: 100, key: const Key('d'))),
               ],
             ),
           ),
         ),
       );
 
-      final wrap = find.byType(Wrap).evaluate().first.widget as Wrap;
-      expect(wrap.runSpacing, 0);
+      final aBottom = tester.getBottomLeft(find.byKey(const Key('a')));
+      final cTop = tester.getTopLeft(find.byKey(const Key('c')));
+      expect(cTop.dy - aBottom.dy, closeTo(0, 1));
     });
 
-    testWidgets('ResponsiveRow respects mainAxisAlignment', (WidgetTester tester) async {
+    testWidgets('ResponsiveRow respects mainAxisAlignment (inner Row)', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -163,11 +192,11 @@ void main() {
         ),
       );
 
-      final wrap = find.byType(Wrap).evaluate().first.widget as Wrap;
-      expect(wrap.alignment, WrapAlignment.center);
+      final row = tester.widget<Row>(find.byType(Row).first);
+      expect(row.mainAxisAlignment, MainAxisAlignment.center);
     });
 
-    testWidgets('ResponsiveRow respects crossAxisAlignment', (WidgetTester tester) async {
+    testWidgets('ResponsiveRow respects crossAxisAlignment (inner Row)', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -181,8 +210,8 @@ void main() {
         ),
       );
 
-      final wrap = find.byType(Wrap).evaluate().first.widget as Wrap;
-      expect(wrap.crossAxisAlignment, WrapCrossAlignment.center);
+      final row = tester.widget<Row>(find.byType(Row).first);
+      expect(row.crossAxisAlignment, CrossAxisAlignment.center);
     });
 
     testWidgets('ResponsiveRow has full width (width: double.infinity)', (WidgetTester tester) async {
@@ -242,7 +271,7 @@ void main() {
       expect(find.byType(ResponsiveCol), findsNothing);
     });
 
-    testWidgets('ResponsiveRow.builder respects mainAxisAlignment', (WidgetTester tester) async {
+    testWidgets('ResponsiveRow.builder respects mainAxisAlignment (inner Row)', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -255,28 +284,35 @@ void main() {
         ),
       );
 
-      final wrap = find.byType(Wrap).evaluate().first.widget as Wrap;
-      expect(wrap.alignment, WrapAlignment.spaceEvenly);
+      final row = tester.widget<Row>(find.byType(Row).first);
+      expect(row.mainAxisAlignment, MainAxisAlignment.spaceEvenly);
     });
 
-    testWidgets('ResponsiveRow.builder respects spacing', (WidgetTester tester) async {
+    testWidgets('ResponsiveRow.builder respects spacing (geometric)', (WidgetTester tester) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 800));
+      addTearDown(tester.view.resetPhysicalSize);
+
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
             body: ResponsiveRow.builder(
-              itemCount: 3,
+              itemCount: 2,
               spacing: 20,
-              itemBuilder: (index) => ResponsiveCol(xs: .col4, child: Container()),
+              itemBuilder: (index) => ResponsiveCol(
+                xs: .col4,
+                child: Container(key: Key('item-$index'), height: 50),
+              ),
             ),
           ),
         ),
       );
 
-      final wrap = find.byType(Wrap).evaluate().first.widget as Wrap;
-      expect(wrap.spacing, 20);
+      final aRight = tester.getTopRight(find.byKey(const Key('item-0')));
+      final bLeft = tester.getTopLeft(find.byKey(const Key('item-1')));
+      expect(bLeft.dx - aRight.dx, closeTo(20, 1));
     });
 
-    testWidgets('ResponsiveRow uses Wrap as layout widget', (WidgetTester tester) async {
+    testWidgets('ResponsiveRow uses LayoutBuilder + Column as layout widgets', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -290,7 +326,9 @@ void main() {
         ),
       );
 
-      expect(find.byType(Wrap), findsOneWidget);
+      expect(find.byType(LayoutBuilder), findsOneWidget);
+      expect(find.byType(Column), findsWidgets);
+      expect(find.byType(Wrap), findsNothing);
     });
 
     testWidgets('ResponsiveRow.builder with large itemCount', (WidgetTester tester) async {
@@ -378,18 +416,25 @@ void main() {
       expect(find.byKey(const Key('test')), findsOneWidget);
     });
 
-    testWidgets('ResponsiveCol uses LayoutBuilder for responsive sizing', (WidgetTester tester) async {
+    testWidgets('ResponsiveCol is a transparent pass-through (no own LayoutBuilder)', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: ResponsiveCol(
-              xs: .col12,
-              child: Container(color: Colors.red, height: 100),
+            body: ResponsiveRow(
+              children: [
+                ResponsiveCol(
+                  xs: .col12,
+                  child: Container(color: Colors.red, height: 100, key: const Key('pass-through')),
+                ),
+              ],
             ),
           ),
         ),
       );
 
+      // Child is discoverable
+      expect(find.byKey(const Key('pass-through')), findsOneWidget);
+      // Only the ResponsiveRow creates exactly one LayoutBuilder, not per-col
       expect(find.byType(LayoutBuilder), findsOneWidget);
     });
 
@@ -521,8 +566,7 @@ void main() {
       expect(find.byType(ResponsiveCol), findsNWidgets(12));
     });
 
-    testWidgets('ResponsiveRow.builder with all parameters',
-        (WidgetTester tester) async {
+    testWidgets('ResponsiveRow.builder with all parameters', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -543,14 +587,12 @@ void main() {
 
       expect(find.byType(ResponsiveCol), findsNWidgets(4));
 
-      final wrap = find.byType(Wrap).evaluate().first.widget as Wrap;
-      expect(wrap.spacing, 10);
-      expect(wrap.alignment, WrapAlignment.spaceEvenly);
-      expect(wrap.crossAxisAlignment, WrapCrossAlignment.center);
+      final row = tester.widget<Row>(find.byType(Row).first);
+      expect(row.mainAxisAlignment, MainAxisAlignment.spaceEvenly);
+      expect(row.crossAxisAlignment, CrossAxisAlignment.center);
     });
 
-    testWidgets('ResponsiveCol with ResponsiveRow preserves layout structure',
-        (WidgetTester tester) async {
+    testWidgets('ResponsiveCol with ResponsiveRow preserves layout structure', (WidgetTester tester) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
@@ -571,7 +613,203 @@ void main() {
       );
 
       expect(find.byKey(const Key('responsive-item')), findsOneWidget);
-      expect(find.byType(Wrap), findsOneWidget);
+      expect(find.byType(LayoutBuilder), findsOneWidget);
+    });
+  });
+
+  // New TDD tests — written RED before implementation (FR-001, FR-002, FR-003, FR-008)
+  group('ResponsiveRow horizontal layout', () {
+    testWidgets('two col6 with spacing=12 at md (W=1000) stay on one row', (WidgetTester tester) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 800));
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ResponsiveRow(
+              spacing: 12,
+              children: [
+                ResponsiveCol(md: .col6, child: Container(key: const Key('a'), height: 50)),
+                ResponsiveCol(md: .col6, child: Container(key: const Key('b'), height: 50)),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final aRect = tester.getRect(find.byKey(const Key('a')));
+      final bRect = tester.getRect(find.byKey(const Key('b')));
+
+      // Both children on the same vertical row
+      expect(aRect.top, closeTo(bRect.top, 1));
+
+      // available = 1000 - 12*(2-1) = 988; each = 988 * 6 / 12 = 494
+      expect(aRect.width, closeTo(494, 1));
+      expect(bRect.width, closeTo(494, 1));
+
+      // Second child starts after first + spacing
+      expect(bRect.left, closeTo(aRect.right + 12, 1));
+    });
+
+    testWidgets('three col4 with spacing=12 at md (W=1000) stay on one row', (WidgetTester tester) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 800));
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ResponsiveRow(
+              spacing: 12,
+              children: [
+                ResponsiveCol(md: .col4, child: Container(key: const Key('a'), height: 50)),
+                ResponsiveCol(md: .col4, child: Container(key: const Key('b'), height: 50)),
+                ResponsiveCol(md: .col4, child: Container(key: const Key('c'), height: 50)),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final aRect = tester.getRect(find.byKey(const Key('a')));
+      final bRect = tester.getRect(find.byKey(const Key('b')));
+      final cRect = tester.getRect(find.byKey(const Key('c')));
+
+      // All three on the same row
+      expect(aRect.top, closeTo(bRect.top, 1));
+      expect(aRect.top, closeTo(cRect.top, 1));
+
+      // available = 1000 - 12*(3-1) = 976; each = 976 * 4 / 12 ≈ 325.33
+      expect(aRect.width, closeTo(325.33, 1));
+      expect(bRect.width, closeTo(325.33, 1));
+      expect(cRect.width, closeTo(325.33, 1));
+    });
+
+    testWidgets('mixed [col6, col6, col4, col4, col4] groups into two rows', (WidgetTester tester) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 800));
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ResponsiveRow(
+              spacing: 12,
+              children: [
+                ResponsiveCol(md: .col6, child: Container(key: const Key('a'), height: 50)),
+                ResponsiveCol(md: .col6, child: Container(key: const Key('b'), height: 50)),
+                ResponsiveCol(md: .col4, child: Container(key: const Key('c'), height: 50)),
+                ResponsiveCol(md: .col4, child: Container(key: const Key('d'), height: 50)),
+                ResponsiveCol(md: .col4, child: Container(key: const Key('e'), height: 50)),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final aRect = tester.getRect(find.byKey(const Key('a')));
+      final bRect = tester.getRect(find.byKey(const Key('b')));
+      final cRect = tester.getRect(find.byKey(const Key('c')));
+      final dRect = tester.getRect(find.byKey(const Key('d')));
+      final eRect = tester.getRect(find.byKey(const Key('e')));
+
+      // Row 1: a and b share same top
+      expect(aRect.top, closeTo(bRect.top, 1));
+
+      // Row 2: c, d, e share same top (which is greater than row 1 top)
+      expect(cRect.top, closeTo(dRect.top, 1));
+      expect(cRect.top, closeTo(eRect.top, 1));
+      expect(cRect.top, greaterThan(aRect.bottom));
+
+      // Vertical gap between row 1 bottom and row 2 top equals spacing (12)
+      expect(cRect.top - aRect.bottom, closeTo(12, 1));
+    });
+
+    testWidgets('spacing=0 produces width = W * g / 12', (WidgetTester tester) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 800));
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ResponsiveRow(
+              spacing: 0,
+              children: [
+                ResponsiveCol(md: .col6, child: Container(key: const Key('a'), height: 50)),
+                ResponsiveCol(md: .col6, child: Container(key: const Key('b'), height: 50)),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final aRect = tester.getRect(find.byKey(const Key('a')));
+      final bRect = tester.getRect(find.byKey(const Key('b')));
+
+      // available = 1000 - 0 = 1000; each = 1000 * 6 / 12 = 500
+      expect(aRect.width, closeTo(500, 1));
+      expect(bRect.width, closeTo(500, 1));
+      // Children are adjacent
+      expect(bRect.left, closeTo(aRect.right, 1));
+    });
+
+    testWidgets('breakpoint transition from xs to md regroups children', (WidgetTester tester) async {
+      // At xs (W < 600): col6 xs default → gridSize 12, so two rows of 1
+      await tester.binding.setSurfaceSize(const Size(500, 800));
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ResponsiveRow(
+              spacing: 0,
+              children: [
+                ResponsiveCol(md: .col6, child: Container(key: const Key('a'), height: 50)),
+                ResponsiveCol(md: .col6, child: Container(key: const Key('b'), height: 50)),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final aRectXs = tester.getRect(find.byKey(const Key('a')));
+      final bRectXs = tester.getRect(find.byKey(const Key('b')));
+      // At xs both cols fill full width → different rows (different top values)
+      expect(bRectXs.top, greaterThan(aRectXs.top));
+
+      // Now transition to md (W=1000)
+      await tester.binding.setSurfaceSize(const Size(1000, 800));
+      await tester.pump();
+
+      final aRectMd = tester.getRect(find.byKey(const Key('a')));
+      final bRectMd = tester.getRect(find.byKey(const Key('b')));
+      // At md both cols are col6 → same row
+      expect(aRectMd.top, closeTo(bRectMd.top, 1));
+    });
+
+    testWidgets('vertical gap between row groups equals spacing', (WidgetTester tester) async {
+      await tester.binding.setSurfaceSize(const Size(1000, 800));
+      addTearDown(tester.view.resetPhysicalSize);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ResponsiveRow(
+              spacing: 16,
+              children: [
+                ResponsiveCol(md: .col6, child: Container(key: const Key('a'), height: 50)),
+                ResponsiveCol(md: .col6, child: Container(key: const Key('b'), height: 50)),
+                ResponsiveCol(md: .col6, child: Container(key: const Key('c'), height: 50)),
+                ResponsiveCol(md: .col6, child: Container(key: const Key('d'), height: 50)),
+              ],
+            ),
+          ),
+        ),
+      );
+
+      final aRect = tester.getRect(find.byKey(const Key('a')));
+      final cRect = tester.getRect(find.byKey(const Key('c')));
+
+      // Row 1: a, b at top; Row 2: c, d below with gap=16
+      expect(cRect.top - aRect.bottom, closeTo(16, 1));
     });
   });
 }


### PR DESCRIPTION
…ter than zero

Bug: with spacing > 0 and children whose gridSizes sum to 12 (e.g. two col6, three col4), the previous Wrap-based render forced unwanted wrapping because each child computed its width as (totalWidth / 12) * gridSize, ignoring the gap. Sum of widths plus spacing exceeded the parent width, so Wrap pushed the last child onto a new row.

Fix: ResponsiveRow now renders via a single LayoutBuilder + Column of Rows. Children are grouped into rows where sum(gridSize) <= 12; for each row of n children, available width is computed as totalWidth - spacing * (n - 1), then each child width is (availableWidth / 12) * gridSize. Vertical gaps between wrapped rows preserved via SizedBox(height: spacing).

ResponsiveCol no longer carries its own LayoutBuilder. The build method returns child directly; breakpoint resolution is delegated to the parent ResponsiveRow via the new package-internal accessor ResponsiveCol.gridSizeAt(double rowWidth). Public API is unchanged.

Behavior note: when spacing > 0, child pixel widths now reflect the gap. A col6 in a two-column row with spacing 12 and total width 1000 measures 494px (was 500px). Layouts with spacing 0 remain pixel-identical.

Tests: 6 new geometric scenarios in test/widgets/responsive_row_test.dart cover two col6, three col4, mixed gridSizes, vertical runSpacing preservation, spacing zero compatibility, and breakpoint transitions. Pre-existing Wrap- coupled assertions were rewritten to use Row/Column geometry. flutter analyze clean. flutter test 417/417 green.

Example: new ResponsiveRowShowcaseView at /grid/responsive-row demonstrates 8 interactive cases (two col6 with spacing, three col4 with tunable spacing, mixed grids, full responsive reflow, vertical gap, builder pattern with ThemedNumberInput, responsive form layout, crossAxisAlignment toggle). Reachable from the home view and the ThemedDrawer sidebar.

Skills: responsive-row and responsive-col SKILL.md plus references/api.md updated to describe the post-7.5.33 render path, the per-row width formula, the row-grouping algorithm, and the new gridSizeAt accessor.

Plugin manifest .claude/plugin.json bumped 7.5.31 -> 7.5.33 to match the package version. pubspec.yaml bumped 7.5.32 -> 7.5.33.

Also: added .atl/ to .gitignore.