### PR TITLE
Expose textInputAction for customizable keyboard actions

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -14,6 +14,7 @@ jobs:
       - uses: goldenm-software/layrz-actions/.github/actions/check-dart@v1
         with:
           flutter-version: "3.44.2"
+          artifact-name: dart-coverage-${{ github.run_id }}
           run-tests: true
 
   coverage-comment:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
       "cwd": "example",
       "request": "launch",
       "type": "dart",
-      "flutterMode":  "profile",
+      "flutterMode": "profile",
       "args": [
         "--profile",
         "--purge-persistent-cache"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 7.7.0
 
 - Added `textInputAction` to `ThemedTextInput`, passed through to the underlying `TextField`. It lets a form declare the keyboard's action key, e.g. `TextInputAction.next` so the key advances to the next field instead of showing the platform default.
+- Update `layrz_model`
 
 ## 7.6.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.7.0
+
+- Added `textInputAction` to `ThemedTextInput`, passed through to the underlying `TextField`. It lets a form declare the keyboard's action key, e.g. `TextInputAction.next` so the key advances to the next field instead of showing the platform default.
+
 ## 7.6.0
 
 - Bumped `layrz_icons` to `^1.1.0`, which renames several Solar icon constants, and updated all internal usages to match (e.g. `solarOutlineMagnifier` → `solarOutlineMagnifer`, `solarOutlineTrashBinMinimalistic2` → `solarOutlineTrashBinMinimalisticN2`, `solarOutlinePalette2` → `solarOutlinePalette`). Consumers passing the renamed constants directly will need to update their references.

--- a/example/lib/views/inputs/src/text.dart
+++ b/example/lib/views/inputs/src/text.dart
@@ -85,18 +85,6 @@ class _TextInputViewState extends State<TextInputView> {
                       labelText: "Example label",
                       placeholder: "Example placeholder",
                       textStyle: TextStyle(color: Colors.purple),
-                      inputFormatters: [
-                        TextInputFormatter.withFunction((oldValue, newValue) {
-                          final regex = RegExp(r'^\d+\,?\d*$');
-                          if (newValue.text.isEmpty) {
-                            return newValue;
-                          }
-                          if (regex.hasMatch(newValue.text)) {
-                            return newValue;
-                          }
-                          return oldValue;
-                        }),
-                      ],
                     ),
                     Text(r"With a Regex formater ^\d+\,?\d*$"),
                     ThemedTextInput(

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -57,6 +57,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  convert:
+    dependency: transitive
+    description:
+      name: convert
+      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   cross_file:
     dependency: transitive
     description:
@@ -113,6 +121,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
+  drift:
+    dependency: transitive
+    description:
+      name: drift
+      sha256: "970cd188fddb111b26ea6a9b07a62bf5c2432d74147b8122c67044ae3b97e99e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.31.0"
+  drift_flutter:
+    dependency: transitive
+    description:
+      name: drift_flutter
+      sha256: c07120854742a0cae2f7501a0da02493addde550db6641d284983c08762e60a7
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.8"
   emojis:
     dependency: transitive
     description:
@@ -348,10 +372,10 @@ packages:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      sha256: "2a743920d81b7910627f68ee2c9ac1fc0bfee32b9fc3403587d7c6791ca12f80"
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.12.0"
   latlong2:
     dependency: transitive
     description:
@@ -368,14 +392,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  layrz_logging:
+    dependency: transitive
+    description:
+      name: layrz_logging
+      sha256: "385b944528b05994bcff70fc435f7fe368dea62670674e1abb34c0824d505027"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
   layrz_models:
     dependency: "direct main"
     description:
       name: layrz_models
-      sha256: "29f773dc382cd3baed03d45c2e266b87ba2690f35f2cb76cda39f8be7110bb19"
+      sha256: ddb2a5313bfadc0ee4abd71f5f4486a26326efbfcca47fc26f8e9c34e50aa63d
       url: "https://pub.dev"
     source: hosted
-    version: "3.4.47"
+    version: "3.18.2"
   layrz_state:
     dependency: "direct main"
     description:
@@ -390,7 +422,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "7.6.0"
+    version: "7.7.0"
   leak_tracker:
     dependency: transitive
     description:
@@ -756,6 +788,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.1"
+  sqlite3:
+    dependency: transitive
+    description:
+      name: sqlite3
+      sha256: "3145bd74dcdb4fd6f5c6dda4d4e4490a8087d7f286a14dee5d37087290f0f8a2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.9.4"
+  sqlite3_flutter_libs:
+    dependency: transitive
+    description:
+      name: sqlite3_flutter_libs
+      sha256: eeb9e3a45207649076b808f8a5a74d68770d0b7f26ccef6d5f43106eee5375ad
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.42"
   stack_trace:
     dependency: transitive
     description:
@@ -956,6 +1004,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
+  web_socket:
+    dependency: transitive
+    description:
+      name: web_socket
+      sha256: "34d64019aa8e36bf9842ac014bb5d2f5586ca73df5e4d9bf5c936975cae6982c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  web_socket_channel:
+    dependency: transitive
+    description:
+      name: web_socket_channel
+      sha256: d645757fb0f4773d602444000a8131ff5d48c9e47adfe9772652dd1a4f2d45c8
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.3"
   win32:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -27,6 +27,13 @@ dependencies:
   layrz_theme:
     path: ../
 
+# layrz_models pulls in layrz_logging, which itself depends on the published layrz_theme. That
+# leaves this app asking for layrz_theme from two sources at once — path here, hosted through
+# logging — which version solving cannot reconcile. Force the local copy for everyone so the
+# example always exercises the sources next to it.
+dependency_overrides:
+  layrz_theme:
+    path: ../
 
 dev_dependencies:
   flutter_test:

--- a/lib/src/inputs/src/general/text_input.dart
+++ b/lib/src/inputs/src/general/text_input.dart
@@ -83,6 +83,10 @@ class ThemedTextInput extends StatefulWidget {
   /// [onSubmitted] is the callback function when the input is submitted.
   final VoidCallback? onSubmitted;
 
+  /// [textInputAction] is the action button of the keyboard, e.g. [TextInputAction.next]
+  /// to display a "next" key instead of the platform default.
+  final TextInputAction? textInputAction;
+
   /// [readonly] is the state of the input being readonly.
   final bool readonly;
 
@@ -160,6 +164,7 @@ class ThemedTextInput extends StatefulWidget {
     this.focusNode,
     this.validator,
     this.onSubmitted,
+    this.textInputAction,
     this.readonly = false,
     this.inputFormatters = const [],
     this.autofillHints = const [],
@@ -431,6 +436,7 @@ class _ThemedTextInputState extends State<ThemedTextInput> with TickerProviderSt
         enabled: !widget.disabled,
         decoration: decoration,
         focusNode: _focusNode,
+        textInputAction: widget.textInputAction,
         inputFormatters: widget.inputFormatters,
         maxLines: widget.maxLines,
         autocorrect: widget.autocorrect,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: layrz_theme
 description: Layrz standard styling library for Flutter. Widget library following the Material Design 3 guidelines, with a focus on reliavility and functionality.
-version: "7.6.0"
+version: "7.7.0"
 homepage: https://theme.layrz.com
 repository: https://github.com/goldenm-software/layrz_theme
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   latlong2: ^0.9.1
   shared_preferences: ^2.5.3
   dio: ^5.8.0
-  layrz_models: ^3.4.3
+  layrz_models: ^3.18.2
   pointer_interceptor: ^0.10.1+2
   two_dimensional_scrollables: ^0.3.4
   sync_scroll_controller: ^1.0.1


### PR DESCRIPTION
This pull request introduces a new feature to the `ThemedTextInput` widget, allowing consumers to specify the keyboard action button (such as "next" or "done") via a new `textInputAction` property. This enables better control over form navigation and improves user experience. The update is documented in the changelog, and the package version is bumped to 7.7.0.

**New Feature: Keyboard Action Customization**
* Added a `textInputAction` property to the `ThemedTextInput` widget, passing it through to the underlying `TextField` so forms can control the keyboard's action key (e.g., set to `TextInputAction.next` to advance to the next field) (`lib/src/inputs/src/general/text_input.dart`) [[1]](diffhunk://#diff-5b6f994a6f88cdffdfe151e64f676a451766364f429bf76ca5e4f0a9866bddb1R86-R89) [[2]](diffhunk://#diff-5b6f994a6f88cdffdfe151e64f676a451766364f429bf76ca5e4f0a9866bddb1R167) [[3]](diffhunk://#diff-5b6f994a6f88cdffdfe151e64f676a451766364f429bf76ca5e4f0a9866bddb1R439).

**Documentation and Versioning**
* Updated `CHANGELOG.md` to document the new `textInputAction` feature in version 7.7.0.
* Bumped package version to 7.7.0 in `pubspec.yaml`.

**Example Cleanup**
* Removed a redundant regex input formatter example from `example/lib/views/inputs/src/text.dart`.