### PR TITLE
feat(tabs): add isScrollable and tabAlignment to ThemedTabView

### DIFF
--- a/.claude/plugin.json
+++ b/.claude/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "layrz-theme",
   "description": "Claude Code skills for layrz-theme Flutter widget library",
-  "version": "7.5.33",
+  "version": "7.8.0",
   "author": {
     "name": "Golden M, Inc.",
     "url": "https://github.com/goldenm-software"

--- a/.claude/skills/themed-tab-view/SKILL.md
+++ b/.claude/skills/themed-tab-view/SKILL.md
@@ -40,7 +40,7 @@ ThemedTabView(
 
 ## Key behaviors
 
-- Tab bar is always scrollable (`TabBar(isScrollable: true)`).
+- Tab bar is scrollable by default; `isScrollable: false` makes the tabs share the full available width (and the active background then fills the whole tab cell).
 - Two styles: `.filledTonal` (default, filled background on active) and `.underline` (bottom border on active).
 - `initialPosition` is clamped to valid range — out-of-range values don't crash.
 - `onTabIndex` fires only when the user **changes** the tab, not on initial mount.
@@ -106,5 +106,14 @@ ThemedTabView(
 ThemedTabView(
   persistTabPosition: false,
   tabs: categories.map((c) => ThemedTab(labelText: c.name, child: CategoryView(c))).toList(),
+)
+
+// Tabs spanning the full width instead of hugging their labels
+ThemedTabView(
+  isScrollable: false,
+  tabs: [
+    ThemedTab(labelText: 'Summary', child: SummaryView()),
+    ThemedTab(labelText: 'Detail', child: DetailView()),
+  ],
 )
 ```

--- a/.claude/skills/themed-tab-view/references/api.md
+++ b/.claude/skills/themed-tab-view/references/api.md
@@ -80,6 +80,8 @@ const ThemedTabView({
   this.additionalWidgets = const [],
   this.style = .filledTonal,
   this.wrapArrowNavigation = false,
+  this.isScrollable = true,
+  this.tabAlignment,
 })
 ```
 
@@ -103,6 +105,8 @@ const ThemedTabView({
 | `crossAxisAlignment` | `CrossAxisAlignment` | `.start` | Vertical alignment of content column |
 | `mainAxisAlignment` | `MainAxisAlignment` | `.start` | Horizontal alignment of content (rarely used) |
 | `physics` | `ScrollPhysics?` | `null` | Scroll physics for `TabBarView` |
+| `isScrollable` | `bool` | `true` | `false` makes tabs share the available width evenly |
+| `tabAlignment` | `TabAlignment?` | `null` | Derived from `isScrollable` when null: `.start` if scrollable, `.fill` if not |
 
 ---
 
@@ -142,6 +146,7 @@ const ThemedTab({
 | `padding` | `EdgeInsets` | `all(10)` | Padding around the tab label area |
 | `color` | `Color?` | `null` | Override tab color (used for active state detection) |
 | `style` | `ThemedTabStyle` | `.filledTonal` | Overridden by parent `ThemedTabView.style` |
+| `expand` | `bool` | `false` | Fills the cell assigned by the `TabBar`. Set by `ThemedTabView` — do not pass manually |
 
 ---
 
@@ -163,7 +168,9 @@ enum ThemedTabStyle {
 
 ## Behavior notes
 
-- Tab bar is always scrollable (`TabBar(isScrollable: true)`).
+- Tab bar is scrollable by default (`isScrollable: true`); pass `isScrollable: false` to make the tabs share the full width.
+- With `isScrollable: false` the active background stretches to the whole cell so it matches the ink splash bounds. Never force `expand` on a scrollable bar — unbounded width throws `BoxConstraints forces an infinite width`.
+- Long labels shrink instead of scrolling when `isScrollable: false`, so it suits a small fixed set of tabs.
 - `onTabIndex` fires only when the user changes the tab (`indexIsChanging` guard) — not on initial mount.
 - `persistTabPosition` only resets to 0 when `tabs.length` changes. Same-length rebuilds always preserve index.
 - `initialPosition` out of range is clamped — no exception thrown.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 7.8.0
+
+- Added `isScrollable` and `tabAlignment` to `ThemedTabView`. `isScrollable` defaults to `true`, which keeps the previous behaviour: every tab takes only the width of its own content and the bar scrolls when the tabs do not fit. Passing `isScrollable: false` makes the tabs share the available width evenly, filling the space left by `additionalWidgets` and the arrow buttons. `tabAlignment` is `null` by default and resolves to `TabAlignment.start` when scrollable and `TabAlignment.fill` when not; set it explicitly only when the value matches `isScrollable`, since Flutter accepts `.start`/`.startOffset` only on a scrollable bar and `.fill`/`.center` only on a non-scrollable one. Both values were previously hardcoded, so there was no way to make the tabs span the full width.
+- Fixed the active tab background not covering the whole tab cell when `isScrollable: false`. The decorated container sized itself to the label while the ink splash always covers the cell the `TabBar` assigned, so the splash painted a visibly larger area than the highlight. `ThemedTab` now takes an `expand` flag — set by `ThemedTabView` through `overrideStyle`, and only when the bar is not scrollable — that stretches the container to fill its cell and centers the label. Scrollable bars are unaffected: they lay tabs out with unbounded width, where expanding would throw `BoxConstraints forces an infinite width`.
+- `ThemedTab.overrideStyle` gained an optional `expand` parameter. The method is used internally by `ThemedTabView`; existing calls keep working unchanged.
+
 ## 7.7.0
 
 - Added `textInputAction` to `ThemedTextInput`, passed through to the underlying `TextField`. It lets a form declare the keyboard's action key, e.g. `TextInputAction.next` so the key advances to the next field instead of showing the platform default.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -422,7 +422,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "7.7.0"
+    version: "7.8.0"
   leak_tracker:
     dependency: transitive
     description:

--- a/lib/src/tabs/src/tab.dart
+++ b/lib/src/tabs/src/tab.dart
@@ -47,6 +47,13 @@ class ThemedTab extends StatelessWidget {
   /// [style] is the style of the tab
   final ThemedTabStyle style;
 
+  /// [expand] makes the tab fill the width of the cell assigned by the [TabBar].
+  ///
+  /// Set by [ThemedTabView] through [overrideStyle]: it is `true` only when the bar is not
+  /// scrollable. A scrollable [TabBar] lays its tabs out with unbounded width, so expanding there
+  /// would assert with `BoxConstraints forces an infinite width`.
+  final bool expand;
+
   /// [ThemedTab] is a tab for the [TabBar] widget
   const ThemedTab({
     super.key,
@@ -61,9 +68,10 @@ class ThemedTab extends StatelessWidget {
     this.color,
     this.child = const SizedBox(),
     this.style = .filledTonal,
+    this.expand = false,
   }) : assert(labelText != null || label != null);
 
-  ThemedTab overrideStyle(ThemedTabStyle newStyle) {
+  ThemedTab overrideStyle(ThemedTabStyle newStyle, {bool? expand}) {
     return ThemedTab(
       key: key,
       labelText: labelText,
@@ -76,6 +84,7 @@ class ThemedTab extends StatelessWidget {
       padding: padding,
       color: color,
       style: newStyle,
+      expand: expand ?? this.expand,
       child: child,
     );
   }
@@ -98,6 +107,11 @@ class ThemedTab extends StatelessWidget {
     return AnimatedContainer(
       duration: _kTabAnimationDuration,
       padding: padding,
+      // When expanded, fill the cell the TabBar assigned to this tab so the active background
+      // matches the ink splash bounds. Otherwise the container shrinks to the label and the splash
+      // paints a visibly larger area than the highlight.
+      width: expand ? double.infinity : null,
+      alignment: expand ? Alignment.center : null,
       decoration: style == .filledTonal
           ? BoxDecoration(
               color: isActive ? backgroundColor.withAlpha((255 * _kTabActiveAlpha).toInt()) : Colors.transparent,
@@ -107,6 +121,7 @@ class ThemedTab extends StatelessWidget {
       child: Padding(
         padding: EdgeInsets.symmetric(horizontal: _kTabInternalPadding),
         child: RichText(
+          textAlign: expand ? TextAlign.center : TextAlign.start,
           text: TextSpan(
             children: [
               if (leading != null || leadingIcon != null) ...[

--- a/lib/src/tabs/src/view.dart
+++ b/lib/src/tabs/src/view.dart
@@ -53,6 +53,23 @@ class ThemedTabView extends StatefulWidget {
   /// When false: arrows are disabled at boundaries
   final bool wrapArrowNavigation;
 
+  /// [isScrollable] is whether the tab bar scrolls horizontally.
+  ///
+  /// When `true` (default) each tab only takes the width of its own content, and the bar scrolls
+  /// when the tabs do not fit. When `false` the tabs share the available width evenly, filling the
+  /// space left by [additionalWidgets] and the arrow buttons.
+  ///
+  /// Keep in mind that `false` makes long labels shrink instead of scroll, so it fits a small,
+  /// fixed set of tabs.
+  final bool isScrollable;
+
+  /// [tabAlignment] is how the tabs are distributed inside the tab bar.
+  ///
+  /// Defaults to `TabAlignment.start` when [isScrollable] is `true` and `TabAlignment.fill` when it
+  /// is `false`. Flutter only accepts `.start`/`.startOffset` on a scrollable bar and
+  /// `.fill`/`.center` on a non-scrollable one, so an explicit value must match [isScrollable].
+  final TabAlignment? tabAlignment;
+
   /// [ThemedTabView] is a tab for the [TabBar] widget
   ///
   /// Be careful!
@@ -73,6 +90,8 @@ class ThemedTabView extends StatefulWidget {
     this.additionalWidgets = const [],
     this.style = .filledTonal,
     this.wrapArrowNavigation = false,
+    this.isScrollable = true,
+    this.tabAlignment,
   });
 
   @override
@@ -141,7 +160,7 @@ class _ThemedTabViewState extends State<ThemedTabView> with TickerProviderStateM
           Theme(
             data: Theme.of(context).copyWith(
               tabBarTheme: Theme.of(context).tabBarTheme.copyWith(
-                tabAlignment: .start,
+                tabAlignment: widget.tabAlignment ?? (widget.isScrollable ? .start : .fill),
                 indicatorColor: widget.style == .filledTonal ? Colors.transparent : null,
               ),
             ),
@@ -170,8 +189,10 @@ class _ThemedTabViewState extends State<ThemedTabView> with TickerProviderStateM
                 ],
                 Expanded(
                   child: TabBar(
-                    isScrollable: true,
-                    tabs: widget.tabs.map((e) => e.overrideStyle(widget.style)).toList(),
+                    isScrollable: widget.isScrollable,
+                    tabs: widget.tabs
+                        .map((e) => e.overrideStyle(widget.style, expand: !widget.isScrollable))
+                        .toList(),
                     labelPadding: .zero,
                     splashBorderRadius: widget.style == .filledTonal ? BorderRadius.circular(_kTabBorderRadius) : null,
                     controller: _tabController,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: layrz_theme
 description: Layrz standard styling library for Flutter. Widget library following the Material Design 3 guidelines, with a focus on reliavility and functionality.
-version: "7.7.0"
+version: "7.8.0"
 homepage: https://theme.layrz.com
 repository: https://github.com/goldenm-software/layrz_theme
 

--- a/test/widgets/tabs_test.dart
+++ b/test/widgets/tabs_test.dart
@@ -880,5 +880,181 @@ void main() {
       expect(leftButton.isDisabled, isFalse);
       expect(rightButton.isDisabled, isFalse);
     });
+
+    testWidgets('isScrollable false makes tabs share the available width', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 600,
+              height: 400,
+              child: ThemedTabView(
+                isScrollable: false,
+                padding: EdgeInsets.zero,
+                tabs: [
+                  ThemedTab(labelText: 'A', child: const Text('Content A')),
+                  ThemedTab(labelText: 'B', child: const Text('Content B')),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final tabBar = tester.widget<TabBar>(find.byType(TabBar));
+      expect(tabBar.isScrollable, isFalse);
+
+      // Both tabs must end up the same width, and each must be wider than its bare label.
+      final containers = find.descendant(
+        of: find.byType(TabBar),
+        matching: find.byType(AnimatedContainer),
+      );
+      final firstWidth = tester.getSize(containers.at(0)).width;
+      final secondWidth = tester.getSize(containers.at(1)).width;
+      expect(firstWidth, equals(secondWidth));
+      expect(firstWidth, greaterThan(100));
+    });
+
+    testWidgets('isScrollable false leaves room for additionalWidgets', (tester) async {
+      const double barWidth = 600;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: barWidth,
+              height: 400,
+              child: ThemedTabView(
+                isScrollable: false,
+                padding: EdgeInsets.zero,
+                additionalWidgets: const [SizedBox(width: 120, height: 40)],
+                tabs: [
+                  ThemedTab(labelText: 'A', child: const Text('Content A')),
+                  ThemedTab(labelText: 'B', child: const Text('Content B')),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      // The extra widget keeps its intrinsic size; only the TabBar gives up space.
+      expect(tester.getSize(find.byType(TabBar)).width, lessThanOrEqualTo(barWidth - 120));
+
+      final containers = find.descendant(
+        of: find.byType(TabBar),
+        matching: find.byType(AnimatedContainer),
+      );
+      final firstWidth = tester.getSize(containers.at(0)).width;
+      final secondWidth = tester.getSize(containers.at(1)).width;
+
+      // Tabs still split evenly, now over the reduced width.
+      expect(firstWidth, equals(secondWidth));
+      expect(firstWidth + secondWidth, lessThanOrEqualTo(barWidth - 120));
+    });
+
+    testWidgets('isScrollable false expands the tab background to the full cell', (tester) async {
+      // Regression: the active background used to shrink to the label while the ink splash covered
+      // the whole cell, so the highlight looked smaller than the splash.
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 600,
+              height: 400,
+              child: ThemedTabView(
+                isScrollable: false,
+                padding: EdgeInsets.zero,
+                tabs: [
+                  ThemedTab(labelText: 'Summary', child: const Text('Content A')),
+                  ThemedTab(labelText: 'B', child: const Text('Content B')),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final containers = find.descendant(
+        of: find.byType(TabBar),
+        matching: find.byType(AnimatedContainer),
+      );
+      final longLabelWidth = tester.getSize(containers.at(0)).width;
+      final shortLabelWidth = tester.getSize(containers.at(1)).width;
+
+      // Both containers fill their own cell, so 'Summary' and 'B' end up identical despite very
+      // different label lengths. Before the fix each shrank to its label and the splash — which
+      // always covers the full cell — painted a visibly larger area than the background.
+      expect(longLabelWidth, equals(shortLabelWidth));
+
+      // And together they span the whole bar, leaving no unpainted gap for the splash to reveal.
+      final barWidth = tester.getSize(find.byType(TabBar)).width;
+      expect(longLabelWidth + shortLabelWidth, moreOrLessEquals(barWidth, epsilon: 1));
+    });
+
+    testWidgets('isScrollable true keeps tabs at their intrinsic width', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 600,
+              height: 400,
+              child: ThemedTabView(
+                padding: EdgeInsets.zero,
+                tabs: [
+                  ThemedTab(labelText: 'A', child: const Text('Content A')),
+                  ThemedTab(labelText: 'a much longer tab label', child: const Text('Content B')),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final tabBar = tester.widget<TabBar>(find.byType(TabBar));
+      expect(tabBar.isScrollable, isTrue);
+
+      // Intrinsic sizing: the long label must be wider than the short one.
+      final containers = find.descendant(
+        of: find.byType(TabBar),
+        matching: find.byType(AnimatedContainer),
+      );
+      final shortWidth = tester.getSize(containers.at(0)).width;
+      final longWidth = tester.getSize(containers.at(1)).width;
+      expect(longWidth, greaterThan(shortWidth));
+
+      // A scrollable TabBar lays tabs out unbounded, so expanding here would assert with
+      // `BoxConstraints forces an infinite width`. Reaching this point proves it does not expand.
+      expect(tester.takeException(), isNull);
+    });
+
+    testWidgets('isScrollable true with additionalWidgets does not overflow', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 600,
+              height: 400,
+              child: ThemedTabView(
+                padding: EdgeInsets.zero,
+                additionalWidgets: const [SizedBox(width: 120, height: 40)],
+                tabs: [
+                  ThemedTab(labelText: 'A', child: const Text('Content A')),
+                  ThemedTab(labelText: 'a much longer tab label', child: const Text('Content B')),
+                ],
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      expect(tester.takeException(), isNull);
+      expect(tester.widget<TabBar>(find.byType(TabBar)).isScrollable, isTrue);
+    });
   });
 }


### PR DESCRIPTION
Both values were hardcoded in the internal TabBar, so there was no way to make the tabs span the full available width.

isScrollable defaults to true, preserving the previous behaviour. Passing false makes the tabs share the width left by additionalWidgets and the arrow buttons. tabAlignment resolves from isScrollable when null, since Flutter only accepts .start/.startOffset on a scrollable bar and .fill/.center on a non-scrollable one.

Also fix the active tab background not covering the whole cell when not scrollable: the container sized itself to the label while the ink splash always covers the assigned cell, so the splash painted a visibly larger area than the highlight. ThemedTab takes an expand flag, set through overrideStyle only when the bar is not scrollable, because a scrollable TabBar lays its tabs out with unbounded width and expanding there throws BoxConstraints forces an infinite width.