### PR TITLE
revert: restore ThemedInputBorder in generateLightTheme and generateD…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 7.9.2
+
+- Reverted the input decoration changes introduced in 7.9.0. `generateLightTheme` and `generateDarkTheme` again render inputs with `ThemedInputBorder` instead of the explicit `OutlineInputBorder` set, and the `errorStyle`/`floatingLabelStyle` and tokenizer-based `contentPadding` added in 7.9.0 were removed. Fonts (`kLayrzFont`) and switch thumb icons are unaffected.
+
 ## 7.9.1
 
 - Updated `layrz_models` to `v3.27.2`

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -414,7 +414,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "7.9.1"
+    version: "7.9.2"
   leak_tracker:
     dependency: transitive
     description:

--- a/lib/src/theme/src/dark_theme.dart
+++ b/lib/src/theme/src/dark_theme.dart
@@ -74,34 +74,14 @@ ThemeData generateDarkTheme({
 
     // Input
     inputDecorationTheme: InputDecorationTheme(
-      contentPadding: LayrzTokenizer.of(null).padding,
+      contentPadding: const .all(10),
       filled: true,
       fillColor: Colors.grey.shade800,
-      focusedBorder: OutlineInputBorder(
-        borderRadius: .circular(10),
-        borderSide: BorderSide(color: Colors.grey.shade700, width: LayrzTokenizer.of(null).borderWidth),
-      ),
-      enabledBorder: OutlineInputBorder(
-        borderRadius: .circular(10),
-        borderSide: BorderSide(color: Colors.grey.shade700, width: LayrzTokenizer.of(null).borderWidth),
-      ),
-      errorBorder: OutlineInputBorder(
-        borderRadius: .circular(10),
-        borderSide: BorderSide(color: LayrzTokenizer.of(null).error, width: LayrzTokenizer.of(null).borderWidth),
-      ),
-      focusedErrorBorder: OutlineInputBorder(
-        borderRadius: .circular(10),
-        borderSide: BorderSide(color: LayrzTokenizer.of(null).error, width: LayrzTokenizer.of(null).borderWidth),
-      ),
-      labelStyle: TextStyle(color: Colors.grey.shade500),
-      errorStyle: textTheme.bodySmall?.copyWith(
-        color: LayrzTokenizer.of(null).error,
-        fontWeight: .bold,
-      ),
-      floatingLabelStyle: TextStyle(color: Colors.grey.shade400, fontWeight: .bold),
-      suffixIconColor: Colors.grey.shade500,
+      border: const ThemedInputBorder(),
+      labelStyle: TextStyle(color: Colors.grey.shade400),
+      suffixIconColor: Colors.grey.shade300,
       suffixStyle: TextStyle(color: Colors.grey.shade400, fontSize: 15),
-      prefixIconColor: Colors.grey.shade500,
+      prefixIconColor: Colors.grey.shade300,
       prefixStyle: TextStyle(color: Colors.grey.shade400, fontSize: 15),
     ),
 

--- a/lib/src/theme/src/light_theme.dart
+++ b/lib/src/theme/src/light_theme.dart
@@ -72,31 +72,11 @@ ThemeData generateLightTheme({
     ),
     // Input
     inputDecorationTheme: InputDecorationTheme(
-      contentPadding: LayrzTokenizer.of(null).padding,
+      contentPadding: const .all(10),
       filled: true,
       fillColor: Colors.grey.shade200,
-      focusedBorder: OutlineInputBorder(
-        borderRadius: .circular(10),
-        borderSide: BorderSide(color: color, width: LayrzTokenizer.of(null).borderWidth),
-      ),
-      enabledBorder: OutlineInputBorder(
-        borderRadius: .circular(10),
-        borderSide: BorderSide(color: Colors.grey.shade200, width: LayrzTokenizer.of(null).borderWidth),
-      ),
-      errorBorder: OutlineInputBorder(
-        borderRadius: .circular(10),
-        borderSide: BorderSide(color: LayrzTokenizer.of(null).error, width: LayrzTokenizer.of(null).borderWidth),
-      ),
-      focusedErrorBorder: OutlineInputBorder(
-        borderRadius: .circular(10),
-        borderSide: BorderSide(color: LayrzTokenizer.of(null).error, width: LayrzTokenizer.of(null).borderWidth),
-      ),
+      border: const ThemedInputBorder(),
       labelStyle: TextStyle(color: Colors.grey.shade600),
-      errorStyle: textTheme.bodySmall?.copyWith(
-        color: LayrzTokenizer.of(null).error,
-        fontWeight: .bold,
-      ),
-      floatingLabelStyle: TextStyle(color: color, fontWeight: .bold),
       suffixIconColor: Colors.grey.shade500,
       suffixStyle: TextStyle(color: Colors.grey.shade600, fontSize: 15),
       prefixIconColor: Colors.grey.shade500,

--- a/lib/src/theme/theme.dart
+++ b/lib/src/theme/theme.dart
@@ -11,7 +11,6 @@ import 'dart:math' as math;
 
 import 'package:layrz_icons/layrz_icons.dart';
 import 'package:layrz_theme/src/theme/src/custom_painters/thumb_shape.dart';
-import 'package:layrz_theme/src/tokenizer/tokenizer.dart';
 
 part 'src/platform.dart';
 part 'src/light_theme.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: layrz_theme
 description: Layrz standard styling library for Flutter. Widget library following the Material Design 3 guidelines, with a focus on reliavility and functionality.
-version: "7.9.1"
+version: "7.9.2"
 homepage: https://theme.layrz.com
 repository: https://github.com/goldenm-software/layrz_theme
 


### PR DESCRIPTION
…arkTheme

Undo the outlined input decoration introduced in 7.9.0. Bump version to 7.9.2 and update changelog.